### PR TITLE
Add bike status change tracking

### DIFF
--- a/src/bike_status_changes.py
+++ b/src/bike_status_changes.py
@@ -15,9 +15,11 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
 
+# Resolve repo root so defaults work regardless of CWD
+REPO_ROOT = Path(__file__).resolve().parents[1]
 # Default locations following project specs
-DEFAULT_DATA_DIR = Path("data/sample/api")
-DEFAULT_DB_PATH = Path("data/processed/bike_data.db")
+DEFAULT_DATA_DIR = REPO_ROOT / "data" / "sample" / "api"
+DEFAULT_DB_PATH = REPO_ROOT / "data" / "processed" / "bike_data.db"
 
 
 def load_snapshot(path: Path) -> Tuple[str, Dict[str, Dict[str, object]]]:
@@ -140,6 +142,7 @@ def save_events_to_db(events: Iterable[Dict[str, object]], db_path: Path) -> Non
     """Insert events into SQLite, creating table if needed."""
     if not events:
         return
+    db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
     try:
         conn.execute(

--- a/src/bike_status_changes.py
+++ b/src/bike_status_changes.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Detect bike status changes between the latest API snapshots.
+
+This script compares the two most recent JSON files downloaded from the
+Nextbike API and records any bike arrivals or departures into an SQLite
+database table called ``bike_status_changes``.
+
+The database path defaults to ``data/processed/bike_data.db`` as defined in
+``docs/SPECS.md``.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+# Default locations following project specs
+DEFAULT_DATA_DIR = Path("data/sample/api")
+DEFAULT_DB_PATH = Path("data/processed/bike_data.db")
+
+
+def load_snapshot(path: Path) -> Tuple[str, Dict[str, Dict[str, object]]]:
+    """Load single snapshot returning timestamp and mapping of bikes.
+
+    Returns
+    -------
+    tuple
+        ``(timestamp_iso, bikes)`` where ``bikes`` maps ``bike_id`` to info
+        about station and bike metadata.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        payload = json.load(f)
+
+    timestamp = payload.get("_fetched_at")
+    places = payload["data"][0]["cities"][0]["places"]
+    bikes: Dict[str, Dict[str, object]] = {}
+
+    for place in places:
+        bikes_list = place.get("bikes") or []
+        if not bikes_list:
+            continue
+        place_type = place.get("placeType")
+        if place_type == "FREESTANDING_BIKE":
+            station_name = "freestanding"
+            station_id = "freestanding"
+        else:
+            station_name = place.get("name")
+            station_id = str(place.get("uid"))
+        lat = place["geoCoords"]["lat"]
+        lon = place["geoCoords"]["lng"]
+        for bike in bikes_list:
+            bike_id = str(bike["number"])
+            bike_type_field = str(bike.get("bikeType", "")).upper()
+            bike_type = "electric" if bike_type_field.startswith("ELECTRIC") else "standard"
+            bikes[bike_id] = {
+                "station_name": station_name,
+                "station_id": station_id,
+                "lat": lat,
+                "lon": lon,
+                "bike_type": bike_type,
+                "battery": bike.get("battery"),
+            }
+    return timestamp, bikes
+
+
+def get_latest_files(data_dir: Path, count: int = 2) -> List[Path]:
+    """Return ``count`` most recent JSON files in ``data_dir``.
+
+    Sorting is based on the ``_fetched_at`` timestamp stored inside each
+    snapshot instead of the filename.
+    """
+    meta = []
+    for path in data_dir.glob("bike_rides_*.json"):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+            meta.append((payload.get("_fetched_at", ""), path))
+        except (OSError, json.JSONDecodeError):
+            continue
+    meta.sort(key=lambda x: x[0])
+    return [p for _, p in meta[-count:]]
+
+
+def diff_snapshots(
+    prev: Dict[str, Dict[str, object]],
+    curr: Dict[str, Dict[str, object]],
+    timestamp: str,
+) -> List[Dict[str, object]]:
+    """Compute arrival/departure events between two snapshots."""
+    events: List[Dict[str, object]] = []
+
+    # Departures and moves
+    for bike_id, info in prev.items():
+        if bike_id not in curr:
+            events.append(
+                {
+                    "timestamp": timestamp,
+                    "bike_id": bike_id,
+                    "event_type": "departed",
+                    **info,
+                }
+            )
+        else:
+            new_info = curr[bike_id]
+            if info["station_id"] != new_info["station_id"]:
+                events.append(
+                    {
+                        "timestamp": timestamp,
+                        "bike_id": bike_id,
+                        "event_type": "departed",
+                        **info,
+                    }
+                )
+                events.append(
+                    {
+                        "timestamp": timestamp,
+                        "bike_id": bike_id,
+                        "event_type": "arrived",
+                        **new_info,
+                    }
+                )
+
+    # Arrivals (new bikes)
+    for bike_id, info in curr.items():
+        if bike_id not in prev:
+            events.append(
+                {
+                    "timestamp": timestamp,
+                    "bike_id": bike_id,
+                    "event_type": "arrived",
+                    **info,
+                }
+            )
+
+    return events
+
+
+def save_events_to_db(events: Iterable[Dict[str, object]], db_path: Path) -> None:
+    """Insert events into SQLite, creating table if needed."""
+    if not events:
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bike_status_changes (
+                uid INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                bike_id TEXT,
+                event_type TEXT,
+                station_name TEXT,
+                station_id TEXT,
+                lat REAL,
+                lon REAL,
+                bike_type TEXT,
+                battery REAL
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO bike_status_changes (
+                timestamp, bike_id, event_type, station_name, station_id,
+                lat, lon, bike_type, battery
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    e["timestamp"],
+                    e["bike_id"],
+                    e["event_type"],
+                    e["station_name"],
+                    e["station_id"],
+                    e["lat"],
+                    e["lon"],
+                    e["bike_type"],
+                    e["battery"],
+                )
+                for e in events
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def main(data_dir: Path = DEFAULT_DATA_DIR, db_path: Path = DEFAULT_DB_PATH) -> None:
+    files = get_latest_files(data_dir, 2)
+    if len(files) < 2:
+        print("[WARN] Not enough JSON files to compare")
+        return
+    ts_prev, prev = load_snapshot(files[0])
+    ts_curr, curr = load_snapshot(files[1])
+    events = diff_snapshots(prev, curr, ts_curr)
+    save_events_to_db(events, db_path)
+    print(f"[OK] Recorded {len(events)} events")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bike_status_changes.py
+++ b/src/bike_status_changes.py
@@ -197,7 +197,7 @@ def main(data_dir: Path = DEFAULT_DATA_DIR, db_path: Path = DEFAULT_DB_PATH) -> 
     ts_curr, curr = load_snapshot(files[1])
     events = diff_snapshots(prev, curr, ts_curr)
     save_events_to_db(events, db_path)
-    print(f"[OK] Recorded {len(events)} events")
+    print(f"[{ts_curr}] [OK] Recorded {len(events)} events")
 
 
 if __name__ == "__main__":

--- a/src/bike_status_changes.py
+++ b/src/bike_status_changes.py
@@ -19,7 +19,7 @@ from typing import Dict, Iterable, List, Tuple
 REPO_ROOT = Path(__file__).resolve().parents[1]
 # Default locations following project specs
 DEFAULT_DATA_DIR = REPO_ROOT / "data" / "sample" / "api"
-DEFAULT_DB_PATH = REPO_ROOT / "data" / "processed" / "bike_data.db"
+DEFAULT_DB_PATH = REPO_ROOT / "data" / "processed" / "bike_status.db"
 
 
 def load_snapshot(path: Path) -> Tuple[str, Dict[str, Dict[str, object]]]:
@@ -197,7 +197,7 @@ def main(data_dir: Path = DEFAULT_DATA_DIR, db_path: Path = DEFAULT_DB_PATH) -> 
     ts_curr, curr = load_snapshot(files[1])
     events = diff_snapshots(prev, curr, ts_curr)
     save_events_to_db(events, db_path)
-    print(f"[OK] Recorded {len(events)} events")
+    print(f"[{ts_curr}] [OK] Recorded {len(events)} events")
 
 
 if __name__ == "__main__":

--- a/tests/test_bike_status_changes.py
+++ b/tests/test_bike_status_changes.py
@@ -1,0 +1,80 @@
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# allow importing from src
+THIS_FILE = Path(__file__).resolve()
+REPO_ROOT = THIS_FILE.parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import bike_status_changes as mod
+
+SAMPLE_DIR = REPO_ROOT / "data" / "sample" / "api"
+
+
+def test_diff_snapshots_detects_events():
+    files = sorted(SAMPLE_DIR.glob("bike_rides_*.json"))[:2]
+    ts1, snap1 = mod.load_snapshot(files[0])
+    ts2, snap2 = mod.load_snapshot(files[1])
+    events = mod.diff_snapshots(snap1, snap2, ts2)
+
+    by_bike = {}
+    for e in events:
+        by_bike.setdefault(e["bike_id"], []).append(e)
+
+    # bike present in first snapshot only -> departed from freestanding
+    evs = by_bike.get("591207")
+    assert evs and evs[0]["event_type"] == "departed"
+    assert evs[0]["station_name"] == "freestanding"
+
+    # bike present in second snapshot only -> arrived to a station
+    evs = by_bike.get("590520")
+    assert evs and evs[0]["event_type"] == "arrived"
+    assert evs[0]["station_name"] == "Żmigrodzka / Broniewskiego"
+
+    # bike moved between locations -> two events
+    evs = by_bike.get("591149")
+    types = {e["event_type"] for e in evs}
+    assert types == {"departed", "arrived"}
+    dep = next(e for e in evs if e["event_type"] == "departed")
+    arr = next(e for e in evs if e["event_type"] == "arrived")
+    assert dep["station_name"] == "Na Grobli (PWr - Geocentrum)"
+    assert arr["station_name"] == "freestanding"
+
+
+def test_save_events_to_db(tmp_path):
+    files = sorted(SAMPLE_DIR.glob("bike_rides_*.json"))[:2]
+    ts1, snap1 = mod.load_snapshot(files[0])
+    ts2, snap2 = mod.load_snapshot(files[1])
+    events = mod.diff_snapshots(snap1, snap2, ts2)
+
+    db_path = tmp_path / "test.db"
+    mod.save_events_to_db(events, db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT event_type, station_name FROM bike_status_changes WHERE bike_id=?",
+            ("591149",),
+        )
+        rows = cur.fetchall()
+        types = {r[0] for r in rows}
+        assert types == {"departed", "arrived"}
+    finally:
+        conn.close()
+
+
+def test_get_latest_files_sort_by_fetched_at(tmp_path):
+    f1 = tmp_path / "bike_rides_a.json"
+    f2 = tmp_path / "bike_rides_b.json"
+    f3 = tmp_path / "bike_rides_c.json"
+    f1.write_text(json.dumps({"_fetched_at": "2025-01-01T00:00:01"}), encoding="utf-8")
+    f2.write_text(json.dumps({"_fetched_at": "2025-01-01T00:00:03"}), encoding="utf-8")
+    f3.write_text(json.dumps({"_fetched_at": "2025-01-01T00:00:02"}), encoding="utf-8")
+    latest = mod.get_latest_files(tmp_path, 2)
+    assert [p.name for p in latest] == ["bike_rides_c.json", "bike_rides_b.json"]


### PR DESCRIPTION
## Summary
- detect bike arrivals and departures between Nextbike API snapshots
- store status change events in new `bike_status_changes` SQLite table
- test status change detection and database persistence using sample API data
- select latest snapshots based on `_fetched_at` timestamps

## Testing
- `pytest tests/test_bike_status_changes.py::test_diff_snapshots_detects_events -q`
- `pytest tests/test_bike_status_changes.py::test_save_events_to_db -q`
- `pytest tests/test_bike_status_changes.py::test_get_latest_files_sort_by_fetched_at -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/wroclaw-bike-stats/data/raw/2025')*

------
https://chatgpt.com/codex/tasks/task_e_68a6295b7718832b99f5e934b5fb29a5