### PR TITLE
#11 - Wrong station name for freestanding electric bikes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# 🚲 Wrocław Bike Stats — data engineering & analytics sandbox
+
+**Wrocław Bike Stats** is an educational *sandbox* project designed for anyone interested in developing their skills in **data engineering**, **data analytics**, and **data science** — based on real, continuously updated data from the Wrocław city bike system.
+
+The project is open and flexible — a great opportunity to learn, experiment, and build your portfolio, regardless of your experience level. Everyone is welcome to join and focus on specific areas of interest. You don’t have to cover everything at once.
+
+## 💡 Main goals of the project
+
+- Create an environment for learning how to work with real-world data
+- Practice real data engineering and analytics tasks
+- Gain experience in team collaboration (Git, PRs, communication)
+- Co-design a data-driven analytics application based on live data
+
+## 🗺 Project roadmap
+
+Below you’ll find a draft “roadmap” highlighting different areas the project covers. As you can see — there’s something interesting here for everyone, no matter your background or interests.
+
+![Project roadmap](ROADMAP.png)
+
+## 🧩 Example tasks you can work on
+
+- Writing SQL queries and analyzing data
+- Designing and managing a database
+- Creating reports and data visualizations
+- Building a dashboard and designing web app features
+- Designing and implementing ETL / data pipelines
+- Developing machine learning models (e.g. predicting daily bike rentals)
+- Practicing collaborative work using Git and GitHub
+
+## 📊 Why is this project interesting?
+
+- We’re working with **real, current, and large-scale data** — over 3.5 million rides in the past two years
+- A great way to gain hands-on experience without the pressure of commercial projects
+- Ideal project to include in your portfolio
+- If you're a data nerd — this is the right place for you
+
+## 👥 Who is this project for?
+
+Anyone — from beginners to experienced data enthusiasts. You can join at any time and work on whatever part of the project interests you most. It’s a typical open-source-style project.
+
+## 📌 Want to join?
+
+Interested or have any questions? Feel free to reach out — I’ll be happy to tell you more.  
+Contact: `wojtek.karcz@gmail.com`

--- a/data/sample/snapA.json
+++ b/data/sample/snapA.json
@@ -1,0 +1,25930 @@
+{
+  "_fetched_at": "2025-08-21T15:05:02+02:00",
+  "data": [
+    {
+      "domain": "pl",
+      "geoCoords": {
+        "lat": 51.1093,
+        "lng": 17.0372
+      },
+      "name": "WRM nextbike Poland",
+      "zoom": 11,
+      "cities": [
+        {
+          "name": "Wrocław",
+          "geoCoords": {
+            "lat": 51.1117,
+            "lng": 17.0357
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "12497516",
+              "brandUid": "pl",
+              "name": "Plac Dominikański (Galeria Dominikańska)",
+              "number": 15001,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.108004,
+                "lng": 17.039528
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 16,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592615,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592014,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591894,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591780,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591615,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591016,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590849,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590336,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590290,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497641",
+              "brandUid": "pl",
+              "name": "Dworzec Główny, południe",
+              "number": 15002,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.097108,
+                "lng": 17.03611
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 12,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592726,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592354,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592271,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592070,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592027,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591814,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591791,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591393,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591087,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590989,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590953,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590866,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590833,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590771,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590522,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590507,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497699",
+              "brandUid": "pl",
+              "name": "Rynek",
+              "number": 15003,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.109782,
+                "lng": 17.030175
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 16,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591876,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591851,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591837,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591023,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590966,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590941,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590520,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590389,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590211,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497748",
+              "brandUid": "pl",
+              "name": "Dworzec Główny ",
+              "number": 15004,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.09975,
+                "lng": 17.036228
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 16,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591827,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591578,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591559,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591295,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591110,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591096,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590749,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590737,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590674,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590523,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590430,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590414,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497776",
+              "brandUid": "pl",
+              "name": "Nowowiejska / Jedności Narodowej",
+              "number": 15005,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.124879,
+                "lng": 17.045844
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592092,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591803,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591226,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590745,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497800",
+              "brandUid": "pl",
+              "name": "Legnicka / Wejherowska",
+              "number": 15006,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.125276,
+                "lng": 16.984447
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592582,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592520,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592146,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591654,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591309,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591127,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591066,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591008,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590975,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590886,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590812,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590690,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590651,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590592,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590483,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590046,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 59
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12497838",
+              "brandUid": "pl",
+              "name": "Rondo Reagana",
+              "number": 15007,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.112154,
+                "lng": 17.060451
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 16,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603869,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592748,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592530,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591953,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591709,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591675,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591421,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591293,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591099,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590511,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590344,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590298,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590255,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590243,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590116,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590099,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 54
+                },
+                {
+                  "number": 590075,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                },
+                {
+                  "number": 590007,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 42
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12497859",
+              "brandUid": "pl",
+              "name": "Pereca / Grabiszyńska",
+              "number": 15008,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.100862,
+                "lng": 17.008224
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592141,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591945,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591917,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590916,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590898,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590840,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590495,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497882",
+              "brandUid": "pl",
+              "name": "Powstańcow Śląskich / Aleja Hallera",
+              "number": 15009,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.086689,
+                "lng": 17.01248
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 14,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592467,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592305,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592122,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591960,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591606,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591564,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591255,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590974,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590789,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590717,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590631,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590380,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497910",
+              "brandUid": "pl",
+              "name": "Grabiszyńska / Aleja Hallera",
+              "number": 15010,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.094413,
+                "lng": 16.980911
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 16,
+                "freeRacks": 14,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590954,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590695,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497965",
+              "brandUid": "pl",
+              "name": "Szczęśliwa (Sky Tower)",
+              "number": 15011,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.094521,
+                "lng": 17.020876
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 45,
+                "bookedBikes": 0,
+                "availableBikes": 45,
+                "bikeRacks": 16,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592881,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592778,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592756,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592743,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592734,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592716,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592569,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592547,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592526,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592522,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592345,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592310,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592248,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592215,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592202,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592088,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592000,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591875,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591842,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591839,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591838,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591805,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591743,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591707,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591688,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591616,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591612,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591610,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591599,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591570,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591297,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591285,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591202,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591047,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590847,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590779,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590675,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590656,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590612,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590454,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590443,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590419,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590281,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590253,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590154,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 45
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498004",
+              "brandUid": "pl",
+              "name": "Śrubowa / Strzegomska",
+              "number": 15012,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.112911,
+                "lng": 17.00136
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591650,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590642,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590636,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498059",
+              "brandUid": "pl",
+              "name": "Na Grobli (PWr - Geocentrum)",
+              "number": 15013,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.105207,
+                "lng": 17.053675
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592376,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591201,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590956,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590822,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590460,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590392,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590124,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498130",
+              "brandUid": "pl",
+              "name": "Lotnicza / Na Ostatnim Groszu",
+              "number": 15014,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.126907,
+                "lng": 16.978759
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592327,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592066,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591778,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591527,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590532,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590142,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590076,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 67
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498262",
+              "brandUid": "pl",
+              "name": "Dyrekcyjna / Borowska (Wroclavia)",
+              "number": 15015,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.095322,
+                "lng": 17.033388
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 14,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592853,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592788,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592762,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592741,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592389,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592350,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592326,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592298,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592257,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592047,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591938,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591828,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591812,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591764,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591519,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591351,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591242,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590814,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590628,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590574,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590464,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590426,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590286,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498285",
+              "brandUid": "pl",
+              "name": "Borowska / Kamienna (Aquapark)",
+              "number": 15016,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.088908,
+                "lng": 17.034051
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 16,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591598,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591575,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591542,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591287,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591251,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591179,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590920,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590883,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590807,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590698,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590359,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590165,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590096,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 59
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498328",
+              "brandUid": "pl",
+              "name": "Wyszyńskiego / Szczytnicka",
+              "number": 15017,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113562,
+                "lng": 17.050674
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 17,
+                "bookedBikes": 0,
+                "availableBikes": 17,
+                "bikeRacks": 16,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592311,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592294,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591949,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591911,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591789,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591694,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591643,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591558,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591197,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591030,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590983,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590972,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590963,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590594,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590401,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590114,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590028,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498353",
+              "brandUid": "pl",
+              "name": "Chałubińskiego / Mikulicza-Radeckiego",
+              "number": 15018,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.111356,
+                "lng": 17.067636
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592725,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592237,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592045,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591840,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591394,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591277,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591070,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590988,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590943,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590688,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590579,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590469,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590422,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590285,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590203,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498400",
+              "brandUid": "pl",
+              "name": "Borowska (Uniw. Szpital Kliniczny)",
+              "number": 15019,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.074868,
+                "lng": 17.032457
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 12,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592473,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592430,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591171,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591095,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590458,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590444,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590031,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 38
+                },
+                {
+                  "number": 590016,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 15
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498514",
+              "brandUid": "pl",
+              "name": "Legnicka (Park Magnolia)",
+              "number": 15020,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.121059,
+                "lng": 16.993088
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 16,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603954,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592816,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592077,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591163,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590915,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590853,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590772,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590673,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590468,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590326,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498723",
+              "brandUid": "pl",
+              "name": "Jagiełły / Dmowskiego ",
+              "number": 15022,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.116596,
+                "lng": 17.023879
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 4,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592241,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591097,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590139,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498752",
+              "brandUid": "pl",
+              "name": "Plac Powstańców Śląskich",
+              "number": 15023,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.091457,
+                "lng": 17.017405
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592546,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592474,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592431,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592404,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592001,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591977,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591732,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591632,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591541,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591537,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591521,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591262,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591187,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591120,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590903,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590679,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590535,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498899",
+              "brandUid": "pl",
+              "name": "Wróblewskiego (ZOO)",
+              "number": 15024,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10592,
+                "lng": 17.075857
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592657,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592585,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592523,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592323,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592107,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591997,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591974,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591733,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591382,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591304,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591130,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590751,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590743,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590663,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590279,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499012",
+              "brandUid": "pl",
+              "name": "Ślężna / Aleja Wiśniowa",
+              "number": 15025,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.084239,
+                "lng": 17.02439
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592810,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592787,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592684,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592132,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592055,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592025,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592002,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591884,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591873,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591865,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591859,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591849,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591441,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591391,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591151,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591075,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591027,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590971,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590838,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590313,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590256,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 21
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499052",
+              "brandUid": "pl",
+              "name": "Tyrmanda / Mińska",
+              "number": 15026,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103216,
+                "lng": 16.9461
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592481,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591507,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591150,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590620,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590346,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499090",
+              "brandUid": "pl",
+              "name": "Janiszewskiego (PWr)",
+              "number": 15027,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.109332,
+                "lng": 17.060511
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 16,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592464,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592403,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591626,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591471,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591358,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590861,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590502,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590319,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499114",
+              "brandUid": "pl",
+              "name": "Norwida / Wyspiańskiego (PWr)",
+              "number": 15028,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.107235,
+                "lng": 17.060715
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 16,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592603,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592439,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591560,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591551,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590686,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499149",
+              "brandUid": "pl",
+              "name": "Plac Świętego Macieja / Trzebnicka",
+              "number": 15029,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.120474,
+                "lng": 17.036641
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592138,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591661,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591378,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591186,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590259,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499256",
+              "brandUid": "pl",
+              "name": "Mińska / Stanisławowska",
+              "number": 15030,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.099401,
+                "lng": 16.941016
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 6,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591726,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591188,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590676,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499294",
+              "brandUid": "pl",
+              "name": "Otyńska / Traktatowa",
+              "number": 15031,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.112322,
+                "lng": 16.973556
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592018,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591533,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591221,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591098,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499354",
+              "brandUid": "pl",
+              "name": "Wita Stwosza / Szewska",
+              "number": 15032,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110274,
+                "lng": 17.034912
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 16,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592528,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592494,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592443,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591855,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591844,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591662,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591136,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590402,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590303,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590260,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590229,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590221,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590112,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499378",
+              "brandUid": "pl",
+              "name": "Plac Kościuszki (Renoma)",
+              "number": 15033,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103354,
+                "lng": 17.030704
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 16,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603943,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592382,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592101,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591774,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590858,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590250,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499401",
+              "brandUid": "pl",
+              "name": "Plac Jana Pawła II (Akademia Muzyczna)",
+              "number": 15034,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.111489,
+                "lng": 17.020981
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592502,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592336,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592099,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591978,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591589,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591484,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591349,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591059,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590815,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590705,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590558,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590543,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590057,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 98
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12499433",
+              "brandUid": "pl",
+              "name": "Plac Uniwersytecki (UWr)",
+              "number": 15035,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.113871,
+                "lng": 17.034484
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 14,
+                "freeRacks": 12,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592258,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590553,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499462",
+              "brandUid": "pl",
+              "name": "Fabryczna / Wagonowa",
+              "number": 15036,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.112726,
+                "lng": 16.988762
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499488",
+              "brandUid": "pl",
+              "name": "Plac Legionów",
+              "number": 15037,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.104413,
+                "lng": 17.022536
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499528",
+              "brandUid": "pl",
+              "name": "Świdnicka / Piłsudskiego (Hotel Scandic)",
+              "number": 15038,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.101319,
+                "lng": 17.028535
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 11,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591976,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591721,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591205,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591042,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590984,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590857,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590355,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590003,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 12
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12499561",
+              "brandUid": "pl",
+              "name": "Kościuszki / Pułaskiego",
+              "number": 15039,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.1004,
+                "lng": 17.045083
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592291,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499586",
+              "brandUid": "pl",
+              "name": "Plac Powstańców Warszawy (Muzeum Narodowe)",
+              "number": 15040,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110001,
+                "lng": 17.047736
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592423,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592285,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592130,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591138,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591116,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590364,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590152,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499606",
+              "brandUid": "pl",
+              "name": "Kościuszki / Komuny Paryskiej / Zgodna",
+              "number": 15041,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.098959,
+                "lng": 17.051519
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592386,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592126,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591782,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591679,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591265,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591143,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590556,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590409,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590275,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590202,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499641",
+              "brandUid": "pl",
+              "name": "Traugutta / Pułaskiego",
+              "number": 15042,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.104571,
+                "lng": 17.048102
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592352,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592301,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592296,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592142,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592116,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592068,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591571,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591026,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590680,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590549,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590218,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590103,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12500063",
+              "brandUid": "pl",
+              "name": "Stacyjna (Dworzec Mikołajów)",
+              "number": 15043,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.115354,
+                "lng": 16.998732
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592415,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591710,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591656,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590926,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590570,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500088",
+              "brandUid": "pl",
+              "name": "Plac Strzegomski / Poznańska",
+              "number": 15044,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113703,
+                "lng": 17.006287
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591724,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500129",
+              "brandUid": "pl",
+              "name": "Zachodnia / Poznańska",
+              "number": 15045,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.117668,
+                "lng": 17.007137
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592280,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500152",
+              "brandUid": "pl",
+              "name": "Drobnera / Dubois",
+              "number": 15046,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.117032,
+                "lng": 17.033499
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 16,
+                "freeRacks": 11,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592629,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592247,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591462,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590746,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590713,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500181",
+              "brandUid": "pl",
+              "name": "Poniatowskiego / Oleśnicka",
+              "number": 15047,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.121308,
+                "lng": 17.043077
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500203",
+              "brandUid": "pl",
+              "name": "Nowowiejska / Wyszyńskiego",
+              "number": 15048,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.122424,
+                "lng": 17.052013
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592367,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592263,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592137,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592074,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590568,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590294,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500217",
+              "brandUid": "pl",
+              "name": "Żeromskiego / Daszyńskiego",
+              "number": 15049,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12566,
+                "lng": 17.050463
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500232",
+              "brandUid": "pl",
+              "name": "Żeromskiego / Kluczborska",
+              "number": 15050,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.122313,
+                "lng": 17.047515
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592497,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591579,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591033,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590758,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590641,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590146,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500254",
+              "brandUid": "pl",
+              "name": "Joliot-Curie (Uwr)",
+              "number": 15051,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110662,
+                "lng": 17.052712
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 16,
+                "freeRacks": 12,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603879,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590485,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590167,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500273",
+              "brandUid": "pl",
+              "name": "Sienkiewicza / Piastowska",
+              "number": 15052,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.115564,
+                "lng": 17.060704
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592483,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591123,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590927,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590589,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500314",
+              "brandUid": "pl",
+              "name": "Sienkiewicza / Wyszyńskiego",
+              "number": 15053,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.116822,
+                "lng": 17.051845
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591863,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591813,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500340",
+              "brandUid": "pl",
+              "name": "Plac Grunwaldzki / Polaka",
+              "number": 15054,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110415,
+                "lng": 17.055591
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 16,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592499,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591639,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591565,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591509,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591196,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591162,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590922,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590876,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590707,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500370",
+              "brandUid": "pl",
+              "name": "Wróblewskiego (Teki)",
+              "number": 15055,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.10411,
+                "lng": 17.084711
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 16,
+                "freeRacks": 16,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500399",
+              "brandUid": "pl",
+              "name": "Komandorska / Sanocka",
+              "number": 15056,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.094653,
+                "lng": 17.026775
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603926,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592792,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592720,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592033,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591981,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591747,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591555,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591386,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591073,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590586,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590489,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500421",
+              "brandUid": "pl",
+              "name": "Ślężna / Kamienna (Uniw. Ekonomiczny)",
+              "number": 15057,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.089842,
+                "lng": 17.028225
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592457,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592363,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592123,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591952,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590783,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590755,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590696,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590604,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590036,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 83
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12500454",
+              "brandUid": "pl",
+              "name": "Oporów (pętla tramwajowa)",
+              "number": 15058,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08451,
+                "lng": 16.97223
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592319,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592308,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592004,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591971,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591820,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590052,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 16
+                },
+                {
+                  "number": 590002,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 24
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12500478",
+              "brandUid": "pl",
+              "name": "Zaporoska / Gajowicka",
+              "number": 15059,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.097209,
+                "lng": 17.013967
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592472,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500501",
+              "brandUid": "pl",
+              "name": "Traugutta / Kościuszki",
+              "number": 15060,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.097147,
+                "lng": 17.056251
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592232,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592136,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591946,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591801,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590618,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500523",
+              "brandUid": "pl",
+              "name": "Nowowiejska / Górnickiego",
+              "number": 15061,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.119311,
+                "lng": 17.056784
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592007,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591499,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591230,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590862,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500551",
+              "brandUid": "pl",
+              "name": "Plac Grunwaldzki (DS Ołówek)",
+              "number": 15062,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113912,
+                "lng": 17.067207
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 16,
+                "freeRacks": 15,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591434,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500568",
+              "brandUid": "pl",
+              "name": "Zaporoska / Grabiszyńska",
+              "number": 15063,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.102117,
+                "lng": 17.013683
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591591,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591573,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590987,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500590",
+              "brandUid": "pl",
+              "name": "Grabiszyńska / Stalowa",
+              "number": 15064,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.099354,
+                "lng": 17.000697
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592548,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592418,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591920,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591596,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591068,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591051,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590554,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500618",
+              "brandUid": "pl",
+              "name": "Krucza / Mielecka / Stalowa",
+              "number": 15065,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.093426,
+                "lng": 17.002893
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591975,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590637,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590348,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500646",
+              "brandUid": "pl",
+              "name": "Aleja Hallera / Mielecka",
+              "number": 15066,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.089315,
+                "lng": 17.001501
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592484,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592369,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591984,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591895,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591886,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591628,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591194,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591134,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591055,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590937,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590643,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590559,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590551,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500681",
+              "brandUid": "pl",
+              "name": "Grochowa / Jemiołowa",
+              "number": 15067,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.095597,
+                "lng": 17.008045
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592740,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592044,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591700,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591646,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591290,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591207,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590909,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590891,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590225,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590111,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500737",
+              "brandUid": "pl",
+              "name": "Legnicka / Młodych Techników",
+              "number": 15069,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113141,
+                "lng": 17.012175
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591737,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591371,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591038,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590829,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590513,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590482,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590213,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500780",
+              "brandUid": "pl",
+              "name": "Żelazna / Pereca",
+              "number": 15070,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.098027,
+                "lng": 17.006977
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591617,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590831,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590761,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590537,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590439,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500803",
+              "brandUid": "pl",
+              "name": "Uniwersytet WSB Merito",
+              "number": 15071,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.108016,
+                "lng": 16.983383
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592102,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591802,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591141,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590980,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590754,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590719,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590480,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590357,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590343,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590224,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500815",
+              "brandUid": "pl",
+              "name": "Szewska / Kazimierza Wielkiego ",
+              "number": 15072,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.107494,
+                "lng": 17.033344
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592343,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592175,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592167,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592059,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591994,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590510,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590330,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500854",
+              "brandUid": "pl",
+              "name": "Na Ostatnim Groszu",
+              "number": 15073,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.122636,
+                "lng": 16.975708
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592666,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592490,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592381,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592322,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592286,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591686,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591103,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590530,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590374,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590297,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590138,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500877",
+              "brandUid": "pl",
+              "name": "Grabiszyńska / Magazynierska (Corte Verona)",
+              "number": 15074,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.096659,
+                "lng": 16.988566
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603937,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592930,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592234,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591704,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590664,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590345,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500893",
+              "brandUid": "pl",
+              "name": "Legnicka / Zachodnia ",
+              "number": 15075,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.117155,
+                "lng": 17.000368
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592496,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592362,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592270,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592267,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591534,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591328,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591148,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591121,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590311,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590149,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590042,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 69
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501008",
+              "brandUid": "pl",
+              "name": "Robotnicza / Fabryczna",
+              "number": 15076,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.112387,
+                "lng": 16.993157
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592281,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591547,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591410,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590917,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590531,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590100,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 71
+                },
+                {
+                  "number": 590043,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 89
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501085",
+              "brandUid": "pl",
+              "name": "Łukasiewicza / Smoluchowskiego (PWr)",
+              "number": 15078,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.108288,
+                "lng": 17.064884
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 28,
+                "freeRacks": 14,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592574,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592397,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591995,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591395,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591209,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590970,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590906,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590897,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590863,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590665,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590341,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590295,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590215,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590158,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501126",
+              "brandUid": "pl",
+              "name": "Kazimierza Wielkiego (Helios)",
+              "number": 15079,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110342,
+                "lng": 17.02601
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 16,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592858,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592297,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591922,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591773,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591517,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591170,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591044,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591015,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590933,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590227,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590024,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 52
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501151",
+              "brandUid": "pl",
+              "name": "Drobnera / Plac Bema",
+              "number": 15080,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.117557,
+                "lng": 17.040967
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592098,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591249,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590784,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590617,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590540,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590473,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501174",
+              "brandUid": "pl",
+              "name": "Krzywoustego - Rynek Psie Pole",
+              "number": 15081,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.147339,
+                "lng": 17.11452
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592562,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592111,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592067,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592034,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591669,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591538,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591329,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591199,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591018,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590872,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590844,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590552,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590438,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590248,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590207,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501209",
+              "brandUid": "pl",
+              "name": "Pilczycka / Kozanowska",
+              "number": 15082,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.13699,
+                "lng": 16.966199
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591930,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590895,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590562,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590026,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 29
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501262",
+              "brandUid": "pl",
+              "name": "Aleja Kromera",
+              "number": 15083,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.132259,
+                "lng": 17.065453
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591046,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501283",
+              "brandUid": "pl",
+              "name": "Leśnica - pętla tramwajowa",
+              "number": 15084,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.14502,
+                "lng": 16.872364
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592468,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592405,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592223,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591905,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591784,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591771,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591763,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591325,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590748,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590304,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501303",
+              "brandUid": "pl",
+              "name": "Krzycka / Aleja Karkonoska (Park Południowy)",
+              "number": 15085,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.074992,
+                "lng": 17.007058
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591760,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591164,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590061,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 64
+                },
+                {
+                  "number": 590025,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 75
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501375",
+              "brandUid": "pl",
+              "name": "Mościckiego (stacja kolejowa)",
+              "number": 15086,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.063834,
+                "lng": 17.083366
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592535,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592182,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592054,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591281,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591114,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591081,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590938,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590081,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 39
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501449",
+              "brandUid": "pl",
+              "name": "Żmigrodzka / Broniewskiego",
+              "number": 15094,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.136111,
+                "lng": 17.036262
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592434,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591906,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590976,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590593,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501499",
+              "brandUid": "pl",
+              "name": "Zwycięska / Ołtaszyńska",
+              "number": 15087,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.059458,
+                "lng": 17.006542
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592882,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591765,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590475,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590104,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 46
+                },
+                {
+                  "number": 590069,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 12
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501561",
+              "brandUid": "pl",
+              "name": "Strzegomska / Estońska",
+              "number": 15088,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.111874,
+                "lng": 16.960692
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591135,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590305,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590058,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 31
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501584",
+              "brandUid": "pl",
+              "name": "Świeradowska (Ferio Gaj )",
+              "number": 15089,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.07692,
+                "lng": 17.041439
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592284,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591767,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591368,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590810,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590536,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590487,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590467,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590251,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590067,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 86
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501733",
+              "brandUid": "pl",
+              "name": "Wałbrzyska - pętla tramwajowa",
+              "number": 15090,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.065777,
+                "lng": 16.988575
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592456,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592251,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592109,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591659,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591658,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591641,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591529,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591432,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591322,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591235,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591195,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591166,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590493,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590399,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501772",
+              "brandUid": "pl",
+              "name": "Buforowa - Vivaldiego",
+              "number": 15091,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.051546,
+                "lng": 17.059094
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592635,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592093,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592083,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591288,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591076,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591060,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590836,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590650,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590331,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590268,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501798",
+              "brandUid": "pl",
+              "name": "Pilczycka (Stadion Miejski)",
+              "number": 15092,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.143633,
+                "lng": 16.950712
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592313,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592282,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592253,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592158,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591040,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590689,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590455,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501819",
+              "brandUid": "pl",
+              "name": "Bardzka / Piękna",
+              "number": 15093,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.085034,
+                "lng": 17.04932
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 26,
+                "bookedBikes": 0,
+                "availableBikes": 26,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592770,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592638,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592553,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592500,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592133,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592094,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592028,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591987,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591811,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591584,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591574,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591501,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591379,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591364,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591341,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591300,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590944,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590942,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590782,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590747,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590709,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590644,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590607,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590300,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590291,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590233,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 26
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501841",
+              "brandUid": "pl",
+              "name": "Tyrmanda / Trawowa",
+              "number": 15095,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.100211,
+                "lng": 16.951602
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501859",
+              "brandUid": "pl",
+              "name": "Zatorska / Królewska - pętla MPK",
+              "number": 15096,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.160332,
+                "lng": 17.133683
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592610,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592551,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592394,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591954,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591861,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591691,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591513,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591354,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591264,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590457,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590023,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 49
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501871",
+              "brandUid": "pl",
+              "name": "Marca Polo (Olimpia Port)",
+              "number": 15097,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.110299,
+                "lng": 17.117854
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 27,
+                "bookedBikes": 0,
+                "availableBikes": 27,
+                "bikeRacks": 8,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592808,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592718,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592544,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592268,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592239,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592178,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592106,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591980,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591885,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591846,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591722,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591684,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591609,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591365,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591211,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591061,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591009,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590985,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590826,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590790,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590711,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590692,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590456,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590273,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590242,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590240,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 27
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501893",
+              "brandUid": "pl",
+              "name": "Osobowicka - pętla tramwajowa",
+              "number": 15098,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.137452,
+                "lng": 16.994705
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592312,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592085,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591217,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590875,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501915",
+              "brandUid": "pl",
+              "name": "Waniliowa / Cynamonowa",
+              "number": 15099,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.17592,
+                "lng": 16.998482
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591766,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501933",
+              "brandUid": "pl",
+              "name": "Żernicka",
+              "number": 15100,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.123237,
+                "lng": 16.924321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592685,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592674,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592420,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592057,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592037,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591957,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591334,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591289,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591131,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591035,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590879,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590762,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590614,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590287,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590264,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590063,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 21
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12914436",
+              "brandUid": "pl",
+              "name": "Centrum Handlowe Auchan Bielany",
+              "number": 15252,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.052723,
+                "lng": 16.968801
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592071,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592061,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591342,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591314,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590837,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590622,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590608,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12914439",
+              "brandUid": "pl",
+              "name": "Aleja Bielany",
+              "number": 15253,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.048391,
+                "lng": 16.961699
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 22,
+                "bookedBikes": 0,
+                "availableBikes": 22,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592399,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592165,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592024,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591986,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591937,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591926,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591889,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591447,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591367,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591303,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591258,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591077,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591010,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590999,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590995,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590732,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590555,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590408,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590301,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590274,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 22
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16333977",
+              "brandUid": "pl",
+              "name": "Obornicka / Bałtycka",
+              "number": 15101,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.136786,
+                "lng": 17.030368
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 14,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592637,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592385,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592306,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592053,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591947,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591753,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591536,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590990,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590832,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590271,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590135,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16333997",
+              "brandUid": "pl",
+              "name": "Berenta / Kasprowicza",
+              "number": 15102,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.138463,
+                "lng": 17.059804
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591648,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591488,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591326,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591239,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590964,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590739,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590545,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334300",
+              "brandUid": "pl",
+              "name": "Kraszewskiego / Trzebnicka",
+              "number": 15103,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12843,
+                "lng": 17.0363
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592823,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592583,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592196,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591621,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591510,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591343,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591129,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590632,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590575,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590391,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334371",
+              "brandUid": "pl",
+              "name": "Grota-Roweckiego / Parafialna",
+              "number": 15104,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06277,
+                "lng": 17.0321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 35,
+                "bookedBikes": 0,
+                "availableBikes": 35,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603896,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592917,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592617,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592607,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592190,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592079,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592065,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591931,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591848,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591719,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591702,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591685,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591568,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591530,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591503,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591319,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591275,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591220,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591216,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591158,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591146,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591107,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590802,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590778,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590756,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590741,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590684,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590647,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590466,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590361,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590317,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590308,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590267,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590150,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 35
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334518",
+              "brandUid": "pl",
+              "name": "Świeradowska / Krynicka",
+              "number": 15105,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.077147,
+                "lng": 17.046785
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592022,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591910,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591192,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591071,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590627,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590600,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334533",
+              "brandUid": "pl",
+              "name": "Krzywoustego / Korona",
+              "number": 15106,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14035,
+                "lng": 17.08494
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 37,
+                "bookedBikes": 0,
+                "availableBikes": 37,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592783,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592753,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592531,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592525,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592478,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592424,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592290,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592266,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592161,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591988,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591823,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591796,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591795,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591583,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591457,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591253,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591244,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591232,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591198,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591165,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591108,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591091,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591053,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591002,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590827,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590819,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590788,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590529,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590505,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590498,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590459,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590349,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590266,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590210,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590145,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590110,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 37
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334561",
+              "brandUid": "pl",
+              "name": "Rogowska / Zemska",
+              "number": 15107,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11869,
+                "lng": 16.95336
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591238,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590981,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334613",
+              "brandUid": "pl",
+              "name": "Hermanowska / Kołobrzeska",
+              "number": 15108,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12353,
+                "lng": 16.95059
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590094,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 98
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "16334773",
+              "brandUid": "pl",
+              "name": "Solskiego / al. Piastów",
+              "number": 15109,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.0775,
+                "lng": 16.96396
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591092,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590027,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 74
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16334924",
+              "brandUid": "pl",
+              "name": "Czekoladowa / Wałbrzyska",
+              "number": 15110,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06404,
+                "lng": 16.97753
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603891,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603883,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592789,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592493,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592428,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592330,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592113,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592026,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591645,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591604,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590653,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590488,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590310,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590119,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590054,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 90
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16334990",
+              "brandUid": "pl",
+              "name": "Tarnogajska / Klimasa",
+              "number": 15111,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08015,
+                "lng": 17.06228
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592411,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591942,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591786,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591775,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591717,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591699,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591500,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591310,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590770,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590410,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335034",
+              "brandUid": "pl",
+              "name": "Opolska / pętla tramwajowa",
+              "number": 15112,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07748,
+                "lng": 17.08405
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592346,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592135,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590420,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335065",
+              "brandUid": "pl",
+              "name": "Graniczna / Strzegomska",
+              "number": 15113,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10702,
+                "lng": 16.94971
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592340,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592273,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592120,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592096,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591256,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591231,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590769,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590660,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590573,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590477,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590452,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590383,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590047,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 86
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335081",
+              "brandUid": "pl",
+              "name": "Żmigrodzka / Marino",
+              "number": 15114,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15013,
+                "lng": 17.02903
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592117,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592017,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591867,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591445,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591180,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591154,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590845,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590791,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590501,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590333,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590071,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 15
+                },
+                {
+                  "number": 590053,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 71
+                },
+                {
+                  "number": 590041,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 17
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335150",
+              "brandUid": "pl",
+              "name": "Kutrzeby / Hubala",
+              "number": 15115,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.056727,
+                "lng": 17.022121
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592203,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592078,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591787,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591693,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591636,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591600,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591139,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590821,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590774,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335230",
+              "brandUid": "pl",
+              "name": "Zwycięska / Agrestowa",
+              "number": 15116,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.0586,
+                "lng": 17.01411
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590143,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335249",
+              "brandUid": "pl",
+              "name": "al. Karkonoska / Jeździecka",
+              "number": 15117,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.061472,
+                "lng": 16.997531
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592641,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592255,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592240,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591944,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591635,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591525,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590912,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590721,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590465,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590328,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590283,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335549",
+              "brandUid": "pl",
+              "name": "Ślężna / Skierniewicka",
+              "number": 15118,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07708,
+                "lng": 17.01824
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603953,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592757,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592576,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592451,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592304,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591829,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591761,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591644,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591512,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591357,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591174,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591011,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590913,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590400,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590131,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590093,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 66
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335560",
+              "brandUid": "pl",
+              "name": "Strzegomska / Rogowska ",
+              "number": 15119,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11059,
+                "lng": 16.95514
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335673",
+              "brandUid": "pl",
+              "name": "Karwińska / Opolska",
+              "number": 15120,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08149,
+                "lng": 17.07693
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592663,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592598,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592124,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591878,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591674,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591627,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591581,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591352,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591243,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591213,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590911,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590786,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590407,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590370,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335708",
+              "brandUid": "pl",
+              "name": "Reymonta / Kleczkowska",
+              "number": 15121,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12695,
+                "lng": 17.02804
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 7,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592527,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592393,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592300,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592269,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591903,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590035,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 60
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335721",
+              "brandUid": "pl",
+              "name": "Młodych Techników",
+              "number": 15122,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.118899,
+                "lng": 17.013477
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592446,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592032,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591948,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591544,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591020,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590811,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590521,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590059,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 78
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335848",
+              "brandUid": "pl",
+              "name": "Popowicka / Niedźwiedzia",
+              "number": 15123,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.1253,
+                "lng": 16.997218
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 5,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590693,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590413,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335861",
+              "brandUid": "pl",
+              "name": "Lotnicza / Metalowców",
+              "number": 15124,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13258,
+                "lng": 16.95697
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603902,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592488,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592391,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592245,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591427,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591296,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591160,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591153,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590567,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335991",
+              "brandUid": "pl",
+              "name": "Zaporoska / Wielka / Krucza",
+              "number": 15125,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09431,
+                "lng": 17.01479
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592163,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591912,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591687,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591505,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591336,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591315,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590385,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336016",
+              "brandUid": "pl",
+              "name": "Maślicka / Stodolna",
+              "number": 15126,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15755,
+                "lng": 16.92781
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592087,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591759,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591240,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590479,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590269,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590163,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336454",
+              "brandUid": "pl",
+              "name": "Bystrzycka / Idzikowskiego",
+              "number": 15127,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12658,
+                "lng": 16.95499
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592639,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592600,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592156,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591554,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590440,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590437,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336520",
+              "brandUid": "pl",
+              "name": "al. Kochanowskiego / Śniadeckich ",
+              "number": 15128,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.120068,
+                "lng": 17.077684
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603958,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592375,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592321,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592081,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591854,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591836,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591756,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591708,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591006,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590936,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590781,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590672,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590550,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590378,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590347,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336553",
+              "brandUid": "pl",
+              "name": "al. Brücknera / Kwidzyńska",
+              "number": 15129,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13198,
+                "lng": 17.07945
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592727,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592672,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592664,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592373,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591999,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591935,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591915,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591817,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591677,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591398,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591161,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591128,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591080,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590978,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590828,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590645,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590431,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590366,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336577",
+              "brandUid": "pl",
+              "name": "Kozanowska / Pilczycka",
+              "number": 15130,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13252,
+                "lng": 16.97377
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336716",
+              "brandUid": "pl",
+              "name": "Pilczycka / Koszykarska",
+              "number": 15131,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.140713,
+                "lng": 16.958199
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591191,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590004,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 40
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16336733",
+              "brandUid": "pl",
+              "name": "al. Jana III Sobieskiego / stacja kolejowa",
+              "number": 15132,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.150227,
+                "lng": 17.118549
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592365,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592293,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591979,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591111,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590842,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590151,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336907",
+              "brandUid": "pl",
+              "name": "Kamieńskiego / Jutrosińska",
+              "number": 15133,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.147082,
+                "lng": 17.042321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591698,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591672,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591362,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591115,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590967,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590870,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590744,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336983",
+              "brandUid": "pl",
+              "name": "Semaforowa",
+              "number": 15134,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.05927,
+                "lng": 17.07877
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337122",
+              "brandUid": "pl",
+              "name": "Olszewskiego / Spółdzielcza",
+              "number": 15135,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10209,
+                "lng": 17.10168
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603903,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592426,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592407,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592302,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592152,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591962,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591825,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591563,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591526,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591335,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591298,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591259,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591185,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591104,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590871,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590798,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590515,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590499,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337271",
+              "brandUid": "pl",
+              "name": "Olszewskiego, pętla tramwajowa",
+              "number": 15136,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.101428,
+                "lng": 17.108523
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 6,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591218,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590777,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337352",
+              "brandUid": "pl",
+              "name": "Bacciarellego",
+              "number": 15137,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.105578,
+                "lng": 17.111316
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592112,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591991,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591821,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591746,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591344,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591340,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590996,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590921,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590808,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590652,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590381,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590060,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 63
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16337500",
+              "brandUid": "pl",
+              "name": "al. Kochanowskiego / Kopernika",
+              "number": 15138,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11514,
+                "lng": 17.07436
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591866,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591745,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591673,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591569,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590977,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337589",
+              "brandUid": "pl",
+              "name": "Bałtycka / Żmigrodzka",
+              "number": 15139,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13959,
+                "lng": 17.03216
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591633,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591586,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591001,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590859,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590288,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337736",
+              "brandUid": "pl",
+              "name": "Bezpieczna / Obornicka",
+              "number": 15140,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14156,
+                "lng": 17.02587
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591897,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591619,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337802",
+              "brandUid": "pl",
+              "name": "Drzewieckiego / Dedala",
+              "number": 15141,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.125652,
+                "lng": 16.968627
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 20,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592348,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592207,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591852,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591655,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591531,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591203,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591017,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590890,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590640,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590416,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590369,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590231,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590021,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 29
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16337827",
+              "brandUid": "pl",
+              "name": "Ślężna / pętla tramwajowa",
+              "number": 15142,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.072302,
+                "lng": 17.012384
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591927,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590638,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337888",
+              "brandUid": "pl",
+              "name": "Mościckiego / Chińska ",
+              "number": 15143,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.05909,
+                "lng": 17.08687
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592765,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592449,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592372,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592236,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592048,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591959,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591871,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591850,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591562,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591511,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591229,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591088,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591085,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590896,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590825,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590449,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590425,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590406,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590134,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590049,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 93
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 20
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16338002",
+              "brandUid": "pl",
+              "name": "Krakowska / Leroy Merlin",
+              "number": 15144,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09053,
+                "lng": 17.06373
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603038,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592894,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592408,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592060,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591705,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591543,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591147,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591021,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590867,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590726,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590492,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590390,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590241,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338057",
+              "brandUid": "pl",
+              "name": "Koszarowa / UWr",
+              "number": 15145,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14128,
+                "lng": 17.06613
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592665,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592552,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592402,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591934,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591870,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591175,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338073",
+              "brandUid": "pl",
+              "name": "Sołtysowicka / Redycka",
+              "number": 15146,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14905,
+                "lng": 17.07565
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 31,
+                "bookedBikes": 0,
+                "availableBikes": 31,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592817,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592652,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592512,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592360,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592356,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592119,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592084,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592082,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592049,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591808,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591792,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591696,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591668,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591549,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591260,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591145,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591048,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590848,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590796,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590752,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590691,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590623,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590572,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590503,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590491,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590470,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590356,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590270,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590169,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590120,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 31
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338172",
+              "brandUid": "pl",
+              "name": "al. Poprzeczna / stacja kolejowa",
+              "number": 15147,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.143302,
+                "lng": 17.08146
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592532,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592374,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592264,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591516,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590725,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590306,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338219",
+              "brandUid": "pl",
+              "name": "Przyjaźni / Karkonoska",
+              "number": 15148,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06841,
+                "lng": 17.00399
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592380,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591714,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591713,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591268,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590605,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590206,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590133,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338267",
+              "brandUid": "pl",
+              "name": "Przyjaźni",
+              "number": 15149,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06667,
+                "lng": 16.99435
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591090,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338338",
+              "brandUid": "pl",
+              "name": "Konduktorska",
+              "number": 15150,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06628,
+                "lng": 17.05825
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592438,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591989,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591857,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591853,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591595,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591546,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590697,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590539,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590323,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590144,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338382",
+              "brandUid": "pl",
+              "name": "Jerzmanowska",
+              "number": 15151,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.120913,
+                "lng": 16.876257
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592640,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592613,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592090,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591078,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590337,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590126,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338506",
+              "brandUid": "pl",
+              "name": "Nyska / Piękna",
+              "number": 15152,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.084669,
+                "lng": 17.053112
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592063,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591003,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590957,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590763,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590630,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338527",
+              "brandUid": "pl",
+              "name": "pl. Powstańców Wielkopolskich",
+              "number": 15153,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12469,
+                "lng": 17.03488
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 8,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591514,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590496,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338671",
+              "brandUid": "pl",
+              "name": "pl. Staszica",
+              "number": 15154,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12266,
+                "lng": 17.02995
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592414,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592013,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591630,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591380,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591257,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590824,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590624,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338780",
+              "brandUid": "pl",
+              "name": "Jedności Narodowej / Wyszyńskiego",
+              "number": 15155,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12814,
+                "lng": 17.05477
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591407,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591133,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338963",
+              "brandUid": "pl",
+              "name": "Mickiewicza / pętla tramwajowa",
+              "number": 15156,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11397,
+                "lng": 17.10395
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592366,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591556,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591350,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591234,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590773,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590715,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590127,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338984",
+              "brandUid": "pl",
+              "name": "al. Armii Krajowej / Borowska",
+              "number": 15157,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08361,
+                "lng": 17.03523
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590949,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590362,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339044",
+              "brandUid": "pl",
+              "name": "Gliniana / Gajowa",
+              "number": 15158,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09152,
+                "lng": 17.04033
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592773,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592669,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592390,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591734,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591729,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591701,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590441,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590382,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590040,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 48
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16339087",
+              "brandUid": "pl",
+              "name": "Kamienna / Tomaszowska",
+              "number": 15159,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.087764,
+                "lng": 17.039318
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592392,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591940,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339118",
+              "brandUid": "pl",
+              "name": "al. Armii Krajowej / Bardzka",
+              "number": 15160,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08283,
+                "lng": 17.04824
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 28,
+                "bookedBikes": 0,
+                "availableBikes": 28,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603945,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603695,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592820,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592729,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592589,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592521,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592432,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592320,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592317,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592260,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592097,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592046,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591996,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591879,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591757,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591723,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591624,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591608,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591567,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591489,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590424,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590352,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590322,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590315,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590292,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590282,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590161,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590137,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 28
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339202",
+              "brandUid": "pl",
+              "name": "Hallera / Odkrywców",
+              "number": 15161,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09126,
+                "lng": 16.98581
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 8,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592928,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592398,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591768,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591324,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339233",
+              "brandUid": "pl",
+              "name": "Skarbowców / Wietrzna",
+              "number": 15162,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07329,
+                "lng": 16.99485
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603935,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592147,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592128,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592075,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590528,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590371,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339243",
+              "brandUid": "pl",
+              "name": "Racławicka / Rymarska",
+              "number": 15163,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08022,
+                "lng": 16.99467
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339272",
+              "brandUid": "pl",
+              "name": "Bajana / Szybowcowa",
+              "number": 15164,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13004,
+                "lng": 16.96605
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592709,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339339",
+              "brandUid": "pl",
+              "name": "Strachocińska / Wieśniacza",
+              "number": 15165,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10666,
+                "lng": 17.14298
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 4,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592450,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591640,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590584,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339373",
+              "brandUid": "pl",
+              "name": "Księgarska / Dekarska / Zduńska",
+              "number": 15166,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.17759,
+                "lng": 17.01588
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592498,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592170,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591794,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591263,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591204,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590681,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590585,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590526,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339408",
+              "brandUid": "pl",
+              "name": "Piękna",
+              "number": 15168,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.085272,
+                "lng": 17.05681
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592459,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592056,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591200,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591032,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339429",
+              "brandUid": "pl",
+              "name": "al. Armii Krajowej / Tarnogajska",
+              "number": 15169,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.083551,
+                "lng": 17.060519
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592913,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592786,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592480,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592462,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591966,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591508,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591069,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590834,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590639,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590542,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590516,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590415,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339489",
+              "brandUid": "pl",
+              "name": "Prochowicka / Dolnobrzeska",
+              "number": 15170,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15127,
+                "lng": 16.86564
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 6,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591225,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591172,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590795,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590064,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16339547",
+              "brandUid": "pl",
+              "name": "Boguszowska / Kosmonautów",
+              "number": 15171,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14395,
+                "lng": 16.89012
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591909,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591883,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591036,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590882,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590200,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339566",
+              "brandUid": "pl",
+              "name": "Popowicka / Rysia",
+              "number": 15172,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.127192,
+                "lng": 16.991832
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592487,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592246,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590514,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590228,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339637",
+              "brandUid": "pl",
+              "name": "Kosmonautów / Glinianki / WUWA2",
+              "number": 15173,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13884,
+                "lng": 16.93191
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590461,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590232,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339816",
+              "brandUid": "pl",
+              "name": "Wilanowska",
+              "number": 15174,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15509,
+                "lng": 17.13249
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 19,
+                "bookedBikes": 0,
+                "availableBikes": 19,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592642,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592105,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592020,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591843,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591622,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591557,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591502,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591283,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591250,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591228,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591212,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591119,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590800,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590613,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590474,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590463,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590262,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590249,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590078,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 24
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16339872",
+              "brandUid": "pl",
+              "name": "Okulickiego",
+              "number": 15175,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.160517,
+                "lng": 17.12231
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592590,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592157,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591830,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590353,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340287",
+              "brandUid": "pl",
+              "name": "Poleska / Litewska",
+              "number": 15176,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.142323,
+                "lng": 17.127246
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592455,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592409,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591831,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591590,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590994,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590716,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590471,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590376,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590329,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590012,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 18
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340385",
+              "brandUid": "pl",
+              "name": "Bacciarellego / pętla autobusowa",
+              "number": 15177,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10224,
+                "lng": 17.11645
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592713,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592476,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592445,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592422,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592387,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592289,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592279,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592250,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592230,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591896,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591799,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591783,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591652,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591214,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591050,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590869,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590767,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590736,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590731,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590533,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590504,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590244,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590157,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340416",
+              "brandUid": "pl",
+              "name": "Średzka / Dolnobrzeska ",
+              "number": 15178,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14597,
+                "lng": 16.86692
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340448",
+              "brandUid": "pl",
+              "name": "Miłoszycka / Swojczycka ",
+              "number": 15179,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11464,
+                "lng": 17.13042
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592643,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592518,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592461,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592377,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591928,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591881,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591748,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591718,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591043,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590928,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590706,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590633,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590324,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340523",
+              "brandUid": "pl",
+              "name": "Stabłowicka / Główna ",
+              "number": 15180,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.16322,
+                "lng": 16.89648
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 22,
+                "bookedBikes": 0,
+                "availableBikes": 22,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592633,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592442,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592368,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592275,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592148,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592114,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591951,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591587,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591157,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591122,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591109,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591086,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591007,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590486,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590436,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590435,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590418,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590332,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590164,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590118,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590088,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 34
+                },
+                {
+                  "number": 590084,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 42
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 20
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340542",
+              "brandUid": "pl",
+              "name": "Wojanowska / Arbuzowa ",
+              "number": 15181,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15435,
+                "lng": 16.89888
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 20,
+                "bookedBikes": 0,
+                "availableBikes": 20,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592758,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592378,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592307,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592191,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592155,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592131,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591916,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591678,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591577,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591476,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591375,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591233,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591178,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591102,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591101,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590986,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590855,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590787,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590561,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590062,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 58
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 19
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340561",
+              "brandUid": "pl",
+              "name": "Osobowicka / Ostrowska",
+              "number": 15182,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14382,
+                "lng": 16.98789
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 3,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592549,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592511,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592351,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592283,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591877,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591770,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591712,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591227,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591079,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590959,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590740,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590658,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590595,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590557,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590490,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590321,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340573",
+              "brandUid": "pl",
+              "name": "Kiełczowska",
+              "number": 15183,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14574,
+                "lng": 17.13493
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592388,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591869,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591703,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591625,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591592,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591515,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591487,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591014,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590958,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590929,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590894,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590670,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590412,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340595",
+              "brandUid": "pl",
+              "name": "Gorlicka / Litewska",
+              "number": 15184,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.141797,
+                "lng": 17.123711
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 34,
+                "bookedBikes": 0,
+                "availableBikes": 34,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592779,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592646,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592619,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592447,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592425,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592328,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592272,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592244,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592188,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591936,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591858,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591736,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591663,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591572,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591490,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591392,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591363,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591333,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591074,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591039,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590931,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590816,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590768,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590730,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590625,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590447,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590395,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590272,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590223,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590216,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590160,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590095,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 26
+                },
+                {
+                  "number": 590020,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 37
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 32
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340625",
+              "brandUid": "pl",
+              "name": "Kasprowicza / Syrokomli",
+              "number": 15185,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.137247,
+                "lng": 17.048546
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590453,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340665",
+              "brandUid": "pl",
+              "name": "Paprotna / Obornicka, zajezdnia MPK",
+              "number": 15186,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.148528,
+                "lng": 17.020477
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 6,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592915,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592441,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590887,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590113,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590010,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 83
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340698",
+              "brandUid": "pl",
+              "name": "Kosmonautów / Fieldorfa, szpital wojewódzki",
+              "number": 15187,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14221,
+                "lng": 16.90591
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340717",
+              "brandUid": "pl",
+              "name": "Stabłowicka ",
+              "number": 15188,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.171074,
+                "lng": 16.902364
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340737",
+              "brandUid": "pl",
+              "name": "Mrągowska / Rolna",
+              "number": 15189,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.149606,
+                "lng": 16.938033
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592503,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591126,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590877,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590014,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 40
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340824",
+              "brandUid": "pl",
+              "name": "Partyzantów / Okrzei",
+              "number": 15190,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.109457,
+                "lng": 17.097924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 33,
+                "bookedBikes": 0,
+                "availableBikes": 33,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592545,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592460,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592287,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592261,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592204,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592072,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591990,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591833,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591772,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591660,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591647,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591582,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591576,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591545,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591535,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591524,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591506,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591132,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591100,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591062,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590930,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590804,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590704,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590682,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590667,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590661,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590648,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590576,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590445,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590427,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590377,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590153,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 33
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340849",
+              "brandUid": "pl",
+              "name": "Hubska / Prudnicka",
+              "number": 15191,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.089572,
+                "lng": 17.045321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603951,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591725,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591716,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591676,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591137,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591052,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340867",
+              "brandUid": "pl",
+              "name": "Jagodzińska / Buforowa",
+              "number": 15192,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.058564,
+                "lng": 17.056696
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603960,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592427,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592259,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592139,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592129,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592086,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592040,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592031,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591670,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591588,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591320,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591308,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591247,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591125,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591063,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590935,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590776,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590720,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590548,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590320,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590252,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590056,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 13
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 23
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340877",
+              "brandUid": "pl",
+              "name": "Kołłątaja / Podwale",
+              "number": 15193,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103854,
+                "lng": 17.03678
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591776,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591749,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591528,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590753,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340895",
+              "brandUid": "pl",
+              "name": "Opolska / Siemianowicka",
+              "number": 15194,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.071275,
+                "lng": 17.090906
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590634,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340965",
+              "brandUid": "pl",
+              "name": "Piaskowa / św. Ducha",
+              "number": 15195,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11289,
+                "lng": 17.03971
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 9,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591804,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591539,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591460,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591442,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590793,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590597,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340992",
+              "brandUid": "pl",
+              "name": "Klecińska / Duńska",
+              "number": 15196,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.109433,
+                "lng": 16.969097
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592134,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591932,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591671,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591637,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590950,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590881,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590668,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16341011",
+              "brandUid": "pl",
+              "name": "pl. Orląt Lwowskich",
+              "number": 15197,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10823,
+                "lng": 17.02138
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 17,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592563,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592238,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592030,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591862,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591739,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590856,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590839,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590316,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590296,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590008,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 25
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16341025",
+              "brandUid": "pl",
+              "name": "Komandorska / Kamienna",
+              "number": 15198,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09009,
+                "lng": 17.0235
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592469,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592150,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591845,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591498,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590710,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590587,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590245,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16341036",
+              "brandUid": "pl",
+              "name": "Wrocław Stadion, stacja kolejowa",
+              "number": 15199,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13673,
+                "lng": 16.941433
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590220,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16341102",
+              "brandUid": "pl",
+              "name": "Wrocław Leśnica, stacja kolejowa",
+              "number": 15200,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14323,
+                "lng": 16.86627
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27523182",
+              "brandUid": "pl",
+              "name": "Grota-Roweckiego/Iwaszkiewicza",
+              "number": 15255,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.05687,
+                "lng": 17.03236
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591993,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591961,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591682,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590115,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27523205",
+              "brandUid": "pl",
+              "name": "Kowalska/Lechitów",
+              "number": 15256,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13197,
+                "lng": 17.11071
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27523212",
+              "brandUid": "pl",
+              "name": "Kamieńskiego",
+              "number": 15257,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15472,
+                "lng": 17.04376
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592736,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592009,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590045,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 78
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "27524242",
+              "brandUid": "pl",
+              "name": "Lubelska/Łukowska",
+              "number": 15258,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.165419,
+                "lng": 16.920266
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592384,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592277,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592265,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592104,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591711,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591520,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591359,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591302,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591224,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590880,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590760,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590734,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590729,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590564,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590373,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590277,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590155,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524256",
+              "brandUid": "pl",
+              "name": "Kwidzyńska pętla",
+              "number": 15259,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12776,
+                "lng": 17.10254
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592421,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592288,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592089,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591810,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591657,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591623,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591566,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591374,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591237,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591024,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590902,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590611,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590394,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590226,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590204,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524262",
+              "brandUid": "pl",
+              "name": "Rakowiecka",
+              "number": 15260,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09761,
+                "lng": 17.06855
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592929,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592470,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592332,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592069,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592008,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591841,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591793,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591738,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591370,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591299,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591222,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591215,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591176,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591045,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590900,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590813,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590794,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590785,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590387,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590238,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590205,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 21
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524326",
+              "brandUid": "pl",
+              "name": "Klecińska (Wrocław Grabiszyn)",
+              "number": 15263,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09724,
+                "lng": 16.97512
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524338",
+              "brandUid": "pl",
+              "name": "Sukielicka / Rogowska",
+              "number": 15264,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.118185,
+                "lng": 16.946011
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 17,
+                "bookedBikes": 0,
+                "availableBikes": 17,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592888,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592777,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592653,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591992,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591982,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591898,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591819,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591762,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591667,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591614,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591585,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591167,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590765,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590417,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590360,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590258,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590123,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 17
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524348",
+              "brandUid": "pl",
+              "name": "Kozanowska/Pałucka",
+              "number": 15265,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13863,
+                "lng": 16.97735
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592897,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592454,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592276,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592233,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592029,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592005,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591933,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591306,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590694,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590610,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590580,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590428,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590338,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590280,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524358",
+              "brandUid": "pl",
+              "name": "Piławska",
+              "number": 15266,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07236,
+                "lng": 17.04294
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592790,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592529,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592058,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592023,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591758,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591438,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591356,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591012,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590478,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590208,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524366",
+              "brandUid": "pl",
+              "name": "Gorlicka/Stanety",
+              "number": 15267,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14518,
+                "lng": 17.11679
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592164,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591887,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590687,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590030,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 13
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "27524375",
+              "brandUid": "pl",
+              "name": "3M",
+              "number": 15268,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.1277,
+                "lng": 17.11456
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590885,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524387",
+              "brandUid": "pl",
+              "name": "Gazowa / Międzyleska",
+              "number": 15269,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07814,
+                "lng": 17.07026
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592315,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592205,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591968,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591809,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591019,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590951,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590946,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590934,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590878,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590817,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590621,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590525,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590500,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590372,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590230,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590148,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524397",
+              "brandUid": "pl",
+              "name": "Bezpieczna/Jugosławiańska",
+              "number": 15270,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13894,
+                "lng": 17.02028
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592717,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592121,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591629,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591190,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591057,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590852,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590805,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590666,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590662,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590254,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590077,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 98
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "50389841",
+              "brandUid": "pl",
+              "name": "Amazon WRO2",
+              "number": 15274,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.034956,
+                "lng": 16.950763
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603952,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592050,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591969,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591943,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591900,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591638,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591034,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590979,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590854,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "62573708",
+              "brandUid": "pl",
+              "name": "Gajowicka",
+              "number": 15201,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.085656,
+                "lng": 17.00453
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590948,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590166,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015132",
+              "brandUid": "pl",
+              "name": "Dalimira/Pęgowska",
+              "number": 15275,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.196906,
+                "lng": 16.974741
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 7,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592021,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591872,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591755,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591603,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591523,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591294,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591169,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591083,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590823,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015172",
+              "brandUid": "pl",
+              "name": "Nowodworska/Strzegomska",
+              "number": 15276,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.114538,
+                "lng": 16.966035
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592798,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591366,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590591,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590005,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 84
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "133015243",
+              "brandUid": "pl",
+              "name": "Kopycińskiego/Drabika",
+              "number": 15278,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.058262,
+                "lng": 17.052487
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 16,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592444,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592035,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591983,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591964,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591681,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591031,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590596,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590209,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015326",
+              "brandUid": "pl",
+              "name": "Czarnuszkowa/Waniliowa",
+              "number": 15280,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.18079,
+                "lng": 16.999845
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590396,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015407",
+              "brandUid": "pl",
+              "name": "Bierutowska",
+              "number": 15281,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.152216,
+                "lng": 17.13217
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592214,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591041,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590201,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590122,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590015,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 73
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "133015775",
+              "brandUid": "pl",
+              "name": "Ziemniaczana/Boiskowa",
+              "number": 15279,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.047299,
+                "lng": 17.091358
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 5,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592453,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592324,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591826,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591680,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590750,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590701,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "138140709",
+              "brandUid": "pl",
+              "name": "Lekarska/Żmigrodzka",
+              "number": 15282,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.161667,
+                "lng": 17.027766
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592100,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591029,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590411,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "149870182",
+              "brandUid": "pl",
+              "name": "Starodębowa (Wrocław Pawłowice)",
+              "number": 15283,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.168502,
+                "lng": 17.109124
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592683,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592177,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591967,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591882,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591522,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591276,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591049,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590246,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590102,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 92
+                },
+                {
+                  "number": 590073,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 93
+                },
+                {
+                  "number": 590070,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 86
+                },
+                {
+                  "number": 590050,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 43
+                },
+                {
+                  "number": 590033,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 100
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "149875085",
+              "brandUid": "pl",
+              "name": "Ibn Siny Awicenny (Wrocław Zachodni)",
+              "number": 15294,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.090573,
+                "lng": 16.950684
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603888,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592347,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592325,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592145,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592062,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592016,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591956,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591781,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591777,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591631,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591155,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591067,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590960,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590952,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590932,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590766,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590714,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590712,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590657,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590494,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590363,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 21
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "150128867",
+              "brandUid": "pl",
+              "name": "Grapowa",
+              "number": 15295,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.061535,
+                "lng": 17.065717
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592612,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592448,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592115,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592041,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591918,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591664,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591280,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591261,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591152,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590677,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590547,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590314,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590051,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "150129540",
+              "brandUid": "pl",
+              "name": "Wrocław Osobowice",
+              "number": 15296,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.166806,
+                "lng": 16.9975
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 5,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592149,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591807,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591390,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591181,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "518093718",
+              "brandUid": "pl",
+              "name": "Powstańców Śląskich/Orla",
+              "number": 15261,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08,
+                "lng": 17.00773
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592052,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591720,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591695,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591642,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591597,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590603,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590234,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520949586",
+              "brandUid": "pl",
+              "name": "Boiskowa / Koreańska",
+              "number": 15308,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.049944,
+                "lng": 17.082919
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592200,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591797,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591540,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591470,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591182,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591094,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590918,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590309,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520950337",
+              "brandUid": "pl",
+              "name": "Swojczycka / Magellana",
+              "number": 15309,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113559,
+                "lng": 17.120977
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 23,
+                "bookedBikes": 0,
+                "availableBikes": 23,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592793,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592791,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592463,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592412,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592076,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591902,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591824,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591769,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591665,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591651,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591552,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591405,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591318,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591241,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591140,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591082,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591013,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590759,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590723,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590405,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590354,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590350,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590130,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 23
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520951174",
+              "brandUid": "pl",
+              "name": "Jerzmanowska / Adamczewskich",
+              "number": 15310,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12056,
+                "lng": 16.866329
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591706,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590818,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590626,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590219,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520951642",
+              "brandUid": "pl",
+              "name": "Jodłowicka",
+              "number": 15311,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.169936,
+                "lng": 16.896987
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592162,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591788,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591754,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591518,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591113,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590733,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590606,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590085,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 33
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "520952092",
+              "brandUid": "pl",
+              "name": "Wrocław Żerniki (stacja kolejowa)",
+              "number": 15312,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12645,
+                "lng": 16.91389
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591550,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591443,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591301,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591208,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591065,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590546,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590497,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590132,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520952430",
+              "brandUid": "pl",
+              "name": "Międzyrzecka",
+              "number": 15313,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09501,
+                "lng": 17.080458
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592410,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543289001",
+              "brandUid": "pl",
+              "name": "Wrocław Wojnów, Przy Torze (przystanek kolejowy)",
+              "number": 15323,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103202,
+                "lng": 17.157738
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592754,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592506,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592189,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592064,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591602,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591561,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591312,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591089,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543289561",
+              "brandUid": "pl",
+              "name": "Awicenny",
+              "number": 15324,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.081686,
+                "lng": 16.956292
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592728,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592604,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592440,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592416,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592295,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592254,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592242,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592110,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592080,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591955,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591815,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591735,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591372,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591219,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591093,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591072,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590955,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590910,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590905,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590619,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590541,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590379,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590159,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590129,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543290242",
+              "brandUid": "pl",
+              "name": "Port Lotniczy",
+              "number": 15325,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110345,
+                "lng": 16.880269
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590590,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590398,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543290642",
+              "brandUid": "pl",
+              "name": "Wrocław Wojszyce (przystanek kolejowy)",
+              "number": 15326,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.068934,
+                "lng": 17.032088
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592396,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591750,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591496,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543291005",
+              "brandUid": "pl",
+              "name": "Marszowicka",
+              "number": 15327,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.16525,
+                "lng": 16.881418
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592419,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592400,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591347,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591245,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590263,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543291628",
+              "brandUid": "pl",
+              "name": "Hala Stulecia",
+              "number": 15328,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.107838,
+                "lng": 17.073909
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592811,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592658,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591963,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591731,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591279,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591193,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591142,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590764,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590518,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590506,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590289,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590128,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543292626",
+              "brandUid": "pl",
+              "name": "Ułańska",
+              "number": 15330,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.054164,
+                "lng": 17.012027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592824,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592554,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591816,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591189,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591004,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590393,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544530233",
+              "brandUid": "pl",
+              "name": "Akademia Wojsk Lądowych",
+              "number": 15338,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.141921,
+                "lng": 17.055193
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591818,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591779,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590797,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590629,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590538,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "558803475",
+              "brandUid": "pl",
+              "name": "BIKE 591106",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273324,
+                "lng": 21.027082
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591106,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "558810060",
+              "brandUid": "pl",
+              "name": "BIKE 591970",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.025782
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591970,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "559097857",
+              "brandUid": "pl",
+              "name": "BIKE 591800",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273502,
+                "lng": 21.027164
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591800,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "560086797",
+              "brandUid": "pl",
+              "name": "BIKE 592588",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273422,
+                "lng": 21.027096
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592588,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561390053",
+              "brandUid": "pl",
+              "name": "BIKE 590214",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273373,
+                "lng": 21.026798
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590214,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561390569",
+              "brandUid": "pl",
+              "name": "BIKE 590156",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272991,
+                "lng": 21.026729
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590156,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561391033",
+              "brandUid": "pl",
+              "name": "BIKE 592596",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.026744
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592596,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561393811",
+              "brandUid": "pl",
+              "name": "BIKE 592924",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273244,
+                "lng": 21.026802
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561394558",
+              "brandUid": "pl",
+              "name": "BIKE 592797",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.2732,
+                "lng": 21.026996
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592797,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561394677",
+              "brandUid": "pl",
+              "name": "BIKE 592938",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273138,
+                "lng": 21.02666
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592938,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561397199",
+              "brandUid": "pl",
+              "name": "BIKE 592747",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273267,
+                "lng": 21.02696
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592747,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561397214",
+              "brandUid": "pl",
+              "name": "BIKE 592771",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273209,
+                "lng": 21.027027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592771,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561397371",
+              "brandUid": "pl",
+              "name": "BIKE 592636",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273324,
+                "lng": 21.027149
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592636,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398354",
+              "brandUid": "pl",
+              "name": "BIKE 592831",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27316,
+                "lng": 21.026862
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592831,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398362",
+              "brandUid": "pl",
+              "name": "BIKE 592895",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273293,
+                "lng": 21.026807
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592895,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398368",
+              "brandUid": "pl",
+              "name": "BIKE 592814",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273302,
+                "lng": 21.026924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592814,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398375",
+              "brandUid": "pl",
+              "name": "BIKE 592796",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273138,
+                "lng": 21.026716
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592796,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398379",
+              "brandUid": "pl",
+              "name": "BIKE 592174",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.2732,
+                "lng": 21.026827
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592174,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398386",
+              "brandUid": "pl",
+              "name": "BIKE 592900",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273093,
+                "lng": 21.026984
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592900,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398388",
+              "brandUid": "pl",
+              "name": "BIKE 592887",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273413,
+                "lng": 21.026676
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592887,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398396",
+              "brandUid": "pl",
+              "name": "BIKE 592921",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273387,
+                "lng": 21.026773
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592921,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398406",
+              "brandUid": "pl",
+              "name": "BIKE 592224",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273316,
+                "lng": 21.026856
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592224,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398417",
+              "brandUid": "pl",
+              "name": "BIKE 592763",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273307,
+                "lng": 21.026727
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592763,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398427",
+              "brandUid": "pl",
+              "name": "BIKE 592939",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273111,
+                "lng": 21.026862
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398437",
+              "brandUid": "pl",
+              "name": "BIKE 592925",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27328,
+                "lng": 21.026904
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398443",
+              "brandUid": "pl",
+              "name": "BIKE 592864",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273071,
+                "lng": 21.026967
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398454",
+              "brandUid": "pl",
+              "name": "BIKE 592774",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273142,
+                "lng": 21.026924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592774,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398468",
+              "brandUid": "pl",
+              "name": "BIKE 592670",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273187,
+                "lng": 21.027027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592670,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398474",
+              "brandUid": "pl",
+              "name": "BIKE 592940",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273062,
+                "lng": 21.026978
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592940,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398481",
+              "brandUid": "pl",
+              "name": "BIKE 592712",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.027047
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592712,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398491",
+              "brandUid": "pl",
+              "name": "BIKE 592923",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273151,
+                "lng": 21.026913
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398495",
+              "brandUid": "pl",
+              "name": "BIKE 592624",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273111,
+                "lng": 21.027038
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592624,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398503",
+              "brandUid": "pl",
+              "name": "BIKE 592901",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273356,
+                "lng": 21.02692
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398509",
+              "brandUid": "pl",
+              "name": "BIKE 592492",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273436,
+                "lng": 21.027009
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592492,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398526",
+              "brandUid": "pl",
+              "name": "BIKE 592676",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273293,
+                "lng": 21.026849
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592676,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398535",
+              "brandUid": "pl",
+              "name": "BIKE 592877",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273244,
+                "lng": 21.026978
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592877,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398542",
+              "brandUid": "pl",
+              "name": "BIKE 592876",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273316,
+                "lng": 21.026727
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592876,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398548",
+              "brandUid": "pl",
+              "name": "BIKE 592841",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273111,
+                "lng": 21.02714
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592841,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398552",
+              "brandUid": "pl",
+              "name": "BIKE 592815",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273138,
+                "lng": 21.027064
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592815,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398561",
+              "brandUid": "pl",
+              "name": "BIKE 592899",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273227,
+                "lng": 21.026998
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398896",
+              "brandUid": "pl",
+              "name": "BIKE 592764",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273338,
+                "lng": 21.027076
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592764,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398904",
+              "brandUid": "pl",
+              "name": "BIKE 592701",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273093,
+                "lng": 21.027067
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592701,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561401031",
+              "brandUid": "pl",
+              "name": "BIKE 592768",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27364,
+                "lng": 21.026622
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592768,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561401034",
+              "brandUid": "pl",
+              "name": "BIKE 592922",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273387,
+                "lng": 21.026816
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592922,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561402042",
+              "brandUid": "pl",
+              "name": "BIKE 592184",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272871,
+                "lng": 21.027184
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592184,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561406565",
+              "brandUid": "pl",
+              "name": "BIKE 592715",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.026782
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592715,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561409693",
+              "brandUid": "pl",
+              "name": "BIKE 592721",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273356,
+                "lng": 21.027096
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592721,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561409708",
+              "brandUid": "pl",
+              "name": "BIKE 592691",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273413,
+                "lng": 21.026862
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592691,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "562450281",
+              "brandUid": "pl",
+              "name": "BIKE 592108",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273169,
+                "lng": 21.026924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592108,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "562529855",
+              "brandUid": "pl",
+              "name": "BIKE 592625",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273373,
+                "lng": 21.0267
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592625,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "562534340",
+              "brandUid": "pl",
+              "name": "BIKE 592465",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273258,
+                "lng": 21.026716
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592465,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "563732126",
+              "brandUid": "pl",
+              "name": "BIKE 592621",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273542,
+                "lng": 21.026704
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592621,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "563857313",
+              "brandUid": "pl",
+              "name": "BIKE 592213",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273022,
+                "lng": 21.02714
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592213,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "564200611",
+              "brandUid": "pl",
+              "name": "BIKE 592519",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273658,
+                "lng": 21.027253
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592519,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566115884",
+              "brandUid": "pl",
+              "name": "BIKE 591124",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273733,
+                "lng": 21.026769
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591124,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566152377",
+              "brandUid": "pl",
+              "name": "BIKE 592125",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.269311,
+                "lng": 21.026336
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592125,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566161353",
+              "brandUid": "pl",
+              "name": "BIKE 591144",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273329,
+                "lng": 21.027182
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591144,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566389890",
+              "brandUid": "pl",
+              "name": "BIKE 590888",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.2732,
+                "lng": 21.027089
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590888,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566592243",
+              "brandUid": "pl",
+              "name": "BIKE 591790",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273302,
+                "lng": 21.027211
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591790,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566677463",
+              "brandUid": "pl",
+              "name": "BIKE 29997",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.186156,
+                "lng": 20.850973
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 29997,
+                  "bikeType": "STANDARD_4G",
+                  "battery": 44
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566870157",
+              "brandUid": "pl",
+              "name": "BIKE 590302",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.128827,
+                "lng": 16.89587
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590302,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566895632",
+              "brandUid": "pl",
+              "name": "BIKE 592211",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.153084,
+                "lng": 16.933566
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592211,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567034187",
+              "brandUid": "pl",
+              "name": "BIKE 590034",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.105711,
+                "lng": 16.962738
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590034,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 56
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567205769",
+              "brandUid": "pl",
+              "name": "BIKE 591037",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27368,
+                "lng": 21.02674
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591037,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567294782",
+              "brandUid": "pl",
+              "name": "BIKE 590945",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.136271,
+                "lng": 16.895524
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590945,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567442008",
+              "brandUid": "pl",
+              "name": "BIKE 591025",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.179387,
+                "lng": 17.045604
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591025,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567472319",
+              "brandUid": "pl",
+              "name": "BIKE 592338",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.055533,
+                "lng": 16.991081
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592338,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567524279",
+              "brandUid": "pl",
+              "name": "BIKE 591028",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.154231,
+                "lng": 16.927016
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591028,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567540054",
+              "brandUid": "pl",
+              "name": "BIKE 591064",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.177929,
+                "lng": 16.878328
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591064,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567593700",
+              "brandUid": "pl",
+              "name": "BIKE 592073",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272756,
+                "lng": 21.026831
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592073,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567603085",
+              "brandUid": "pl",
+              "name": "BIKE 590257",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.115973,
+                "lng": 16.989622
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590257,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567603706",
+              "brandUid": "pl",
+              "name": "BIKE 590044",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.105569,
+                "lng": 17.043994
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590044,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 27
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567723537",
+              "brandUid": "pl",
+              "name": "BIKE 590072",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.111711,
+                "lng": 17.027127
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590072,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 53
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567736798",
+              "brandUid": "pl",
+              "name": "BIKE 591605",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.123204,
+                "lng": 17.05415
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591605,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567777592",
+              "brandUid": "pl",
+              "name": "BIKE 590893",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.01416,
+                "lng": 16.95746
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567789749",
+              "brandUid": "pl",
+              "name": "BIKE 592678",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.092809,
+                "lng": 16.982056
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592678,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567800641",
+              "brandUid": "pl",
+              "name": "BIKE 603949",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.042933,
+                "lng": 16.942776
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603949,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567816738",
+              "brandUid": "pl",
+              "name": "BIKE 590582",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.05552,
+                "lng": 16.991132
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590582,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567817483",
+              "brandUid": "pl",
+              "name": "BIKE 590577",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.070631,
+                "lng": 16.994879
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590577,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567843175",
+              "brandUid": "pl",
+              "name": "BIKE 591168",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.0966,
+                "lng": 17.009943
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591168,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567858729",
+              "brandUid": "pl",
+              "name": "BIKE 591950",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.192911,
+                "lng": 16.978119
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591950,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567865166",
+              "brandUid": "pl",
+              "name": "BIKE 590074",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.115436,
+                "lng": 17.052866
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590074,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 35
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567875698",
+              "brandUid": "pl",
+              "name": "BIKE 590293",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.138076,
+                "lng": 16.874902
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590293,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567905551",
+              "brandUid": "pl",
+              "name": "BIKE 590342",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.274511,
+                "lng": 21.026978
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590342,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567950275",
+              "brandUid": "pl",
+              "name": "BIKE 592742",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.146769,
+                "lng": 16.940857
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592742,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567969108",
+              "brandUid": "pl",
+              "name": "BIKE 592299",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.138516,
+                "lng": 17.035514
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592299,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567978034",
+              "brandUid": "pl",
+              "name": "BIKE 591785",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.095071,
+                "lng": 16.96071
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591785,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567978075",
+              "brandUid": "pl",
+              "name": "BIKE 590588",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.068898,
+                "lng": 16.967994
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590588,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568011049",
+              "brandUid": "pl",
+              "name": "BIKE 590048",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.116391,
+                "lng": 16.985292
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590048,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 32
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568015828",
+              "brandUid": "pl",
+              "name": "BIKE 590462",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.028613,
+                "lng": 16.965578
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590462,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568019981",
+              "brandUid": "pl",
+              "name": "BIKE 590450",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103444,
+                "lng": 17.07135
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590450,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568021042",
+              "brandUid": "pl",
+              "name": "BIKE 590090",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.140049,
+                "lng": 16.852759
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590090,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 64
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568049726",
+              "brandUid": "pl",
+              "name": "BIKE 591613",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.154987,
+                "lng": 16.923942
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591613,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568055781",
+              "brandUid": "pl",
+              "name": "BIKE 591744",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.099747,
+                "lng": 17.013491
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591744,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568094079",
+              "brandUid": "pl",
+              "name": "BIKE 592406",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.135978,
+                "lng": 16.928434
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592406,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568094100",
+              "brandUid": "pl",
+              "name": "BIKE 591159",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.136,
+                "lng": 16.9284
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591159,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568094726",
+              "brandUid": "pl",
+              "name": "BIKE 590079",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.105698,
+                "lng": 16.962864
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590079,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 39
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568101482",
+              "brandUid": "pl",
+              "name": "BIKE 590086",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.074471,
+                "lng": 17.016462
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590086,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 96
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568136614",
+              "brandUid": "pl",
+              "name": "BIKE 592012",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.10768,
+                "lng": 17.05081
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592012,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568138918",
+              "brandUid": "pl",
+              "name": "BIKE 592011",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.037404,
+                "lng": 16.956544
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592011,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568141127",
+              "brandUid": "pl",
+              "name": "BIKE 590609",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.172262,
+                "lng": 17.113332
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590609,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568149210",
+              "brandUid": "pl",
+              "name": "BIKE 591307",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.0382,
+                "lng": 16.952179
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591307,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568150279",
+              "brandUid": "pl",
+              "name": "BIKE 591305",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.11132,
+                "lng": 16.996612
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591305,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568151844",
+              "brandUid": "pl",
+              "name": "BIKE 592262",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.056307,
+                "lng": 16.990583
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592262,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568159982",
+              "brandUid": "pl",
+              "name": "BIKE 590904",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.107609,
+                "lng": 17.027606
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568163463",
+              "brandUid": "pl",
+              "name": "BIKE 591173",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.055484,
+                "lng": 16.991091
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591173,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568164084",
+              "brandUid": "pl",
+              "name": "BIKE 590924",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.113756,
+                "lng": 17.094046
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568171511",
+              "brandUid": "pl",
+              "name": "BIKE 591056",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103982,
+                "lng": 17.152159
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591056,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568178184",
+              "brandUid": "pl",
+              "name": "BIKE 590125",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110716,
+                "lng": 17.043831
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590125,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568186602",
+              "brandUid": "pl",
+              "name": "BIKE 592784",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.114271,
+                "lng": 17.058748
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592784,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568201271",
+              "brandUid": "pl",
+              "name": "BIKE 591210",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.093627,
+                "lng": 17.024027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591210,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568204204",
+              "brandUid": "pl",
+              "name": "BIKE 590809",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.060938,
+                "lng": 16.993292
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590809,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568206909",
+              "brandUid": "pl",
+              "name": "BIKE 592514",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.114524,
+                "lng": 17.043751
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592514,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568207250",
+              "brandUid": "pl",
+              "name": "BIKE 590278",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.099022,
+                "lng": 17.028631
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590278,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568208359",
+              "brandUid": "pl",
+              "name": "BIKE 590386",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.117489,
+                "lng": 17.073588
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590386,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568215983",
+              "brandUid": "pl",
+              "name": "BIKE 592627",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.132667,
+                "lng": 17.046957
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592627,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568221896",
+              "brandUid": "pl",
+              "name": "BIKE 592436",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.154142,
+                "lng": 17.066961
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592436,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568222612",
+              "brandUid": "pl",
+              "name": "BIKE 591715",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103613,
+                "lng": 17.070627
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591715,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568224162",
+              "brandUid": "pl",
+              "name": "BIKE 590803",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110409,
+                "lng": 17.109276
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590803,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568227292",
+              "brandUid": "pl",
+              "name": "BIKE 590998",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.118769,
+                "lng": 17.052494
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590998,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568236126",
+              "brandUid": "pl",
+              "name": "BIKE 591348",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.112338,
+                "lng": 16.979502
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591348,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568243054",
+              "brandUid": "pl",
+              "name": "BIKE 592662",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.085893,
+                "lng": 17.014599
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592662,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568243288",
+              "brandUid": "pl",
+              "name": "BIKE 591620",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.053302,
+                "lng": 16.989723
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591620,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568245655",
+              "brandUid": "pl",
+              "name": "BIKE 592019",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110693,
+                "lng": 17.043783
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592019,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568245734",
+              "brandUid": "pl",
+              "name": "BIKE 590820",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110711,
+                "lng": 17.043751
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590820,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568245956",
+              "brandUid": "pl",
+              "name": "BIKE 591223",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.126529,
+                "lng": 17.058647
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591223,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568246734",
+              "brandUid": "pl",
+              "name": "BIKE 590442",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.1126,
+                "lng": 16.978527
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590442,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568247305",
+              "brandUid": "pl",
+              "name": "BIKE 590484",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.161089,
+                "lng": 16.873661
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590484,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568248492",
+              "brandUid": "pl",
+              "name": "BIKE 591317",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.092733,
+                "lng": 17.034178
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591317,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568252429",
+              "brandUid": "pl",
+              "name": "BIKE 590635",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.071884,
+                "lng": 17.033848
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590635,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568253160",
+              "brandUid": "pl",
+              "name": "BIKE 590097",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.116413,
+                "lng": 17.068441
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590097,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 83
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568254736",
+              "brandUid": "pl",
+              "name": "BIKE 590299",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.10796,
+                "lng": 17.078044
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590299,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568254747",
+              "brandUid": "pl",
+              "name": "BIKE 590654",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.10796,
+                "lng": 17.078052
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590654,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255007",
+              "brandUid": "pl",
+              "name": "BIKE 592581",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.134538,
+                "lng": 16.958221
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592581,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255274",
+              "brandUid": "pl",
+              "name": "BIKE 591692",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.159267,
+                "lng": 17.022949
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591692,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255300",
+              "brandUid": "pl",
+              "name": "BIKE 590121",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103622,
+                "lng": 17.070642
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590121,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255591",
+              "brandUid": "pl",
+              "name": "BIKE 592292",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.146556,
+                "lng": 16.948444
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592292,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568258196",
+              "brandUid": "pl",
+              "name": "BIKE 590327",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.100676,
+                "lng": 17.023834
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590327,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568260530",
+              "brandUid": "pl",
+              "name": "BIKE 591248",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.148187,
+                "lng": 17.079756
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591248,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568263648",
+              "brandUid": "pl",
+              "name": "BIKE 592379",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103604,
+                "lng": 17.063112
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592379,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568263795",
+              "brandUid": "pl",
+              "name": "BIKE 591345",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272876,
+                "lng": 21.025269
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591345,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568264413",
+              "brandUid": "pl",
+              "name": "BIKE 592192",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.14584,
+                "lng": 17.030066
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592192,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568265577",
+              "brandUid": "pl",
+              "name": "BIKE 591607",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.13312,
+                "lng": 16.991368
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591607,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568265670",
+              "brandUid": "pl",
+              "name": "BIKE 590646",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.098258,
+                "lng": 16.99098
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590646,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568266586",
+              "brandUid": "pl",
+              "name": "BIKE 592318",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.11752,
+                "lng": 17.003473
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592318,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568266669",
+              "brandUid": "pl",
+              "name": "BIKE 590534",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.114516,
+                "lng": 16.990972
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590534,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568267505",
+              "brandUid": "pl",
+              "name": "BIKE 590066",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.14448,
+                "lng": 16.854524
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590066,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 30
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568267575",
+              "brandUid": "pl",
+              "name": "BIKE 591832",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.104787,
+                "lng": 16.946632
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591832,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Kobierzyce (WRM)",
+          "geoCoords": {
+            "lat": 51.0481,
+            "lng": 17.0025
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "189897679",
+              "brandUid": "pl",
+              "name": "Bielany Wrocławskie Kolejowa P&R",
+              "number": 15302,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.03795,
+                "lng": 16.976374
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603947,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592038,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591958,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591697,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591634,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591346,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590683,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590678,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590566,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590476,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "189898068",
+              "brandUid": "pl",
+              "name": "Wysoka/Nastrojowa",
+              "number": 15303,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.052835,
+                "lng": 17.003956
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592799,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592335,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592103,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591177,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590140,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544488536",
+              "brandUid": "pl",
+              "name": "Wysoka Parkowa / Lipowa",
+              "number": 15339,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.042472,
+                "lng": 17.014538
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592794,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592417,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591730,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591361,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591246,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591022,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590993,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590598,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590423,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590261,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590087,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 61
+                },
+                {
+                  "number": 590055,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 31
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "544488870",
+              "brandUid": "pl",
+              "name": "Ślęza Parkowa",
+              "number": 15340,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.034473,
+                "lng": 16.993278
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603941,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592870,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592413,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592140,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591618,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591497,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591311,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590519,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590429,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567698511",
+              "brandUid": "pl",
+              "name": "BIKE 590384",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.038884,
+                "lng": 16.972551
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590384,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568252693",
+              "brandUid": "pl",
+              "name": "BIKE 590388",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.030138,
+                "lng": 16.999451
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590388,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Wisznia (WRM)",
+          "geoCoords": {
+            "lat": 51.2479,
+            "lng": 17.0442
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "190517322",
+              "brandUid": "pl",
+              "name": "Psary Centrum",
+              "number": 15306,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.185896,
+                "lng": 17.029398
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592370,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591206,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590961,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590801,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590649,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590512,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590318,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590265,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590107,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 27
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            }
+          ]
+        },
+        {
+          "name": "Kąty Wrocławskie (WRM)",
+          "geoCoords": {
+            "lat": 51.0773,
+            "lng": 16.9133
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "190503572",
+              "brandUid": "pl",
+              "name": "Mokronos Górny PKP",
+              "number": 15304,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.078886,
+                "lng": 16.908149
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592749,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592730,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592722,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592719,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592703,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592466,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592437,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592429,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592010,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590508,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590106,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 63
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "190512283",
+              "brandUid": "pl",
+              "name": "Smolec",
+              "number": 15305,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.087048,
+                "lng": 16.911286
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592711,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592091,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591941,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590965,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590799,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517286",
+              "brandUid": "pl",
+              "name": "Stawowa / Wiśniowa Mokronos Dolny",
+              "number": 15315,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.07055,
+                "lng": 16.936889
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592785,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592752,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592737,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592735,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592706,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590375,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517297",
+              "brandUid": "pl",
+              "name": "Wrocławska / Spacerowa Mokronos Górny",
+              "number": 15316,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.074457,
+                "lng": 16.919512
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592878,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592819,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592630,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592565,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592558,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592556,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592524,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592517,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592508,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592036,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591847,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591000,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590962,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590780,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590659,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590655,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590563,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590524,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590365,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590340,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590276,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590168,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590162,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Siechnice (WRM)",
+          "geoCoords": {
+            "lat": 51.0334,
+            "lng": 17.1471
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "540517728",
+              "brandUid": "pl",
+              "name": "Osiedlowa/Ciepłownicza Siechnice",
+              "number": 15317,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.025382,
+                "lng": 17.153896
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603964,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603933,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603890,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603884,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603873,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603866,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590339,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517820",
+              "brandUid": "pl",
+              "name": "Siechnice PKP",
+              "number": 15318,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.038098,
+                "lng": 17.144258
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591921,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591913,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591593,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591278,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517956",
+              "brandUid": "pl",
+              "name": "Siechnice UM",
+              "number": 15319,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.032555,
+                "lng": 17.150512
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603929,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592632,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592504,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592208,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592006,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591751,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591338,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591183,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590982,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590973,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590742,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590718,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590578,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590335,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590222,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590032,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 52
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "540517982",
+              "brandUid": "pl",
+              "name": "Radwanice ul. Kolejowa (Biedronka)",
+              "number": 15322,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.057135,
+                "lng": 17.105197
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 20,
+                "bookedBikes": 0,
+                "availableBikes": 20,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592690,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592507,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592475,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592309,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592194,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592169,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592118,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591880,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591449,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591377,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590992,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590865,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590722,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590703,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590472,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590358,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590307,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590217,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590141,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590136,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 20
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540518130",
+              "brandUid": "pl",
+              "name": "Żerniki Wrocławskie Pętla",
+              "number": 15321,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.033391,
+                "lng": 17.056056
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603920,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603905,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591058,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590841,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540518329",
+              "brandUid": "pl",
+              "name": "Święta Katarzyna PKP",
+              "number": 15320,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.029405,
+                "lng": 17.123084
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603911,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592916,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591890,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590735,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590434,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590212,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Czernica (WRM)",
+          "geoCoords": {
+            "lat": 51.087,
+            "lng": 17.1812
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "544486355",
+              "brandUid": "pl",
+              "name": "Kamieniec Wrocławski - Szkoła",
+              "number": 15331,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.077945,
+                "lng": 17.17357
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592910,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592680,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592649,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592550,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592542,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592495,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591891,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591353,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591316,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544486619",
+              "brandUid": "pl",
+              "name": "Dobrzykowice P&R",
+              "number": 15332,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.086982,
+                "lng": 17.18119
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603961,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603955,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603909,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603898,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603886,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603885,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603863,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544486874",
+              "brandUid": "pl",
+              "name": "Dobrzykowice ul. Szkolna",
+              "number": 15333,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.094503,
+                "lng": 17.192763
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603781,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592724,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592707,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592668,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592609,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592560,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590884,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590775,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590727,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590601,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590599,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590098,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 39
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            }
+          ]
+        }
+      ],
+      "isMainDomain": true
+    }
+  ]
+}

--- a/data/sample/snapB.json
+++ b/data/sample/snapB.json
@@ -1,0 +1,25896 @@
+{
+  "_fetched_at": "2025-08-21T15:06:02+02:00",
+  "data": [
+    {
+      "domain": "pl",
+      "geoCoords": {
+        "lat": 51.1093,
+        "lng": 17.0372
+      },
+      "name": "WRM nextbike Poland",
+      "zoom": 11,
+      "cities": [
+        {
+          "name": "Wrocław",
+          "geoCoords": {
+            "lat": 51.1117,
+            "lng": 17.0357
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "12497516",
+              "brandUid": "pl",
+              "name": "Plac Dominikański (Galeria Dominikańska)",
+              "number": 15001,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.108004,
+                "lng": 17.039528
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 16,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592615,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592014,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591894,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591780,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591615,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591016,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590849,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590336,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590290,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497641",
+              "brandUid": "pl",
+              "name": "Dworzec Główny, południe",
+              "number": 15002,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.097108,
+                "lng": 17.03611
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 12,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592726,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592354,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592271,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592070,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592027,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591814,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591791,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591393,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590989,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590953,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590866,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590833,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590771,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590522,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590507,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497699",
+              "brandUid": "pl",
+              "name": "Rynek",
+              "number": 15003,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.109782,
+                "lng": 17.030175
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 16,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591876,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591851,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591837,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591023,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590966,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590941,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590520,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590389,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590211,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497748",
+              "brandUid": "pl",
+              "name": "Dworzec Główny ",
+              "number": 15004,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.09975,
+                "lng": 17.036228
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 16,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591578,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591559,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591295,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591110,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590737,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590674,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590523,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590430,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590414,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497776",
+              "brandUid": "pl",
+              "name": "Nowowiejska / Jedności Narodowej",
+              "number": 15005,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.124879,
+                "lng": 17.045844
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592092,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591803,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591226,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590745,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497800",
+              "brandUid": "pl",
+              "name": "Legnicka / Wejherowska",
+              "number": 15006,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.125276,
+                "lng": 16.984447
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592582,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592520,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592146,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591654,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591309,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591127,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591066,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591008,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590975,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590886,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590812,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590690,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590651,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590592,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590483,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590046,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 59
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12497838",
+              "brandUid": "pl",
+              "name": "Rondo Reagana",
+              "number": 15007,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.112154,
+                "lng": 17.060451
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 16,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603869,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592748,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592530,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591953,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591709,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591675,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591421,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591293,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591099,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590511,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590344,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590298,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590255,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590243,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590116,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590099,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 54
+                },
+                {
+                  "number": 590075,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                },
+                {
+                  "number": 590007,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 42
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12497859",
+              "brandUid": "pl",
+              "name": "Pereca / Grabiszyńska",
+              "number": 15008,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.100862,
+                "lng": 17.008224
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592141,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591945,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591917,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590916,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590898,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590840,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590495,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497882",
+              "brandUid": "pl",
+              "name": "Powstańcow Śląskich / Aleja Hallera",
+              "number": 15009,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.086689,
+                "lng": 17.01248
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 14,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592467,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592305,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592122,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591960,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591606,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591564,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591255,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590974,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590789,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590717,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590631,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590380,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497910",
+              "brandUid": "pl",
+              "name": "Grabiszyńska / Aleja Hallera",
+              "number": 15010,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.094413,
+                "lng": 16.980911
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 16,
+                "freeRacks": 14,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590954,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590695,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12497965",
+              "brandUid": "pl",
+              "name": "Szczęśliwa (Sky Tower)",
+              "number": 15011,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.094521,
+                "lng": 17.020876
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 45,
+                "bookedBikes": 0,
+                "availableBikes": 45,
+                "bikeRacks": 16,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592881,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592778,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592756,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592743,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592734,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592716,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592569,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592547,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592526,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592522,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592345,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592310,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592248,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592215,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592202,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592088,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592000,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591875,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591842,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591839,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591838,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591805,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591743,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591707,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591688,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591616,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591612,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591610,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591599,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591570,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591297,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591285,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591202,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591047,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590847,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590779,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590675,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590656,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590612,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590454,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590443,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590419,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590281,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590253,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590154,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 45
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498004",
+              "brandUid": "pl",
+              "name": "Śrubowa / Strzegomska",
+              "number": 15012,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.112911,
+                "lng": 17.00136
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591650,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590642,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590636,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498059",
+              "brandUid": "pl",
+              "name": "Na Grobli (PWr - Geocentrum)",
+              "number": 15013,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.105207,
+                "lng": 17.053675
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592376,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591201,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590956,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590822,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590460,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590392,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590124,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498130",
+              "brandUid": "pl",
+              "name": "Lotnicza / Na Ostatnim Groszu",
+              "number": 15014,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.126907,
+                "lng": 16.978759
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592327,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592066,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591778,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591527,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590532,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590142,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590076,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 67
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498262",
+              "brandUid": "pl",
+              "name": "Dyrekcyjna / Borowska (Wroclavia)",
+              "number": 15015,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.095322,
+                "lng": 17.033388
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 14,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592853,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592788,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592762,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592741,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592389,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592350,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592326,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592298,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592257,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592047,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591938,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591828,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591812,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591764,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591519,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591351,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591242,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590814,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590628,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590574,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590464,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590426,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590286,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498285",
+              "brandUid": "pl",
+              "name": "Borowska / Kamienna (Aquapark)",
+              "number": 15016,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.088908,
+                "lng": 17.034051
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 16,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591598,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591575,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591542,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591287,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591251,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591179,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590920,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590883,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590807,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590698,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590359,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590165,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590096,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 59
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498328",
+              "brandUid": "pl",
+              "name": "Wyszyńskiego / Szczytnicka",
+              "number": 15017,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113562,
+                "lng": 17.050674
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 17,
+                "bookedBikes": 0,
+                "availableBikes": 17,
+                "bikeRacks": 16,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592311,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592294,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591949,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591911,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591789,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591694,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591643,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591558,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591197,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591030,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590983,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590972,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590963,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590594,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590401,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590114,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590028,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498353",
+              "brandUid": "pl",
+              "name": "Chałubińskiego / Mikulicza-Radeckiego",
+              "number": 15018,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.111356,
+                "lng": 17.067636
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592725,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592237,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592045,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591840,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591394,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591277,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591070,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590988,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590943,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590688,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590579,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590469,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590422,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590285,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590203,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498400",
+              "brandUid": "pl",
+              "name": "Borowska (Uniw. Szpital Kliniczny)",
+              "number": 15019,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.074868,
+                "lng": 17.032457
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 12,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592473,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592430,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591171,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591095,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590458,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590444,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590031,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 38
+                },
+                {
+                  "number": 590016,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 15
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12498514",
+              "brandUid": "pl",
+              "name": "Legnicka (Park Magnolia)",
+              "number": 15020,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.121059,
+                "lng": 16.993088
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 16,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603954,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592816,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592077,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591163,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590915,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590853,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590772,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590673,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590468,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590326,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498723",
+              "brandUid": "pl",
+              "name": "Jagiełły / Dmowskiego ",
+              "number": 15022,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.116596,
+                "lng": 17.023879
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 4,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592241,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591097,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590139,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498752",
+              "brandUid": "pl",
+              "name": "Plac Powstańców Śląskich",
+              "number": 15023,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.091457,
+                "lng": 17.017405
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592546,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592474,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592431,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592404,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592001,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591977,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591732,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591632,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591541,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591537,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591521,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591262,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591187,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591120,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590903,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590679,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590535,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12498899",
+              "brandUid": "pl",
+              "name": "Wróblewskiego (ZOO)",
+              "number": 15024,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10592,
+                "lng": 17.075857
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592657,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592585,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592523,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592323,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592107,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591997,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591974,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591733,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591382,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591304,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591130,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590751,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590743,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590663,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590279,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499012",
+              "brandUid": "pl",
+              "name": "Ślężna / Aleja Wiśniowa",
+              "number": 15025,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.084239,
+                "lng": 17.02439
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592810,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592787,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592684,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592132,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592055,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592025,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592002,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591884,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591873,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591865,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591859,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591849,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591441,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591391,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591151,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591075,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591027,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590971,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590838,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590313,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590256,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 21
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499052",
+              "brandUid": "pl",
+              "name": "Tyrmanda / Mińska",
+              "number": 15026,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103216,
+                "lng": 16.9461
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592481,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591832,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591507,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591150,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590620,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590346,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499090",
+              "brandUid": "pl",
+              "name": "Janiszewskiego (PWr)",
+              "number": 15027,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.109332,
+                "lng": 17.060511
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 16,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592464,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592403,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591626,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591471,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591358,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590861,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590569,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590502,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590319,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499114",
+              "brandUid": "pl",
+              "name": "Norwida / Wyspiańskiego (PWr)",
+              "number": 15028,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.107235,
+                "lng": 17.060715
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 16,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592603,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592439,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591560,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591551,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590686,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499149",
+              "brandUid": "pl",
+              "name": "Plac Świętego Macieja / Trzebnicka",
+              "number": 15029,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.120474,
+                "lng": 17.036641
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592138,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591661,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591378,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591186,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590259,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499256",
+              "brandUid": "pl",
+              "name": "Mińska / Stanisławowska",
+              "number": 15030,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.099401,
+                "lng": 16.941016
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 6,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591726,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591188,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590676,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499294",
+              "brandUid": "pl",
+              "name": "Otyńska / Traktatowa",
+              "number": 15031,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.112322,
+                "lng": 16.973556
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592018,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591533,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591221,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591098,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499354",
+              "brandUid": "pl",
+              "name": "Wita Stwosza / Szewska",
+              "number": 15032,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110274,
+                "lng": 17.034912
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 16,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592528,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592494,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592443,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591855,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591844,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591662,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591136,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590544,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590402,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590303,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590260,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590229,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590221,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590112,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499378",
+              "brandUid": "pl",
+              "name": "Plac Kościuszki (Renoma)",
+              "number": 15033,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103354,
+                "lng": 17.030704
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 16,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603943,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592382,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592101,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591774,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590858,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590250,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499401",
+              "brandUid": "pl",
+              "name": "Plac Jana Pawła II (Akademia Muzyczna)",
+              "number": 15034,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.111489,
+                "lng": 17.020981
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592502,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592336,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592099,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591978,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591589,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591484,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591349,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591059,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590815,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590705,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590558,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590543,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590057,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 98
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12499433",
+              "brandUid": "pl",
+              "name": "Plac Uniwersytecki (UWr)",
+              "number": 15035,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.113871,
+                "lng": 17.034484
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 14,
+                "freeRacks": 12,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592258,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590553,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499462",
+              "brandUid": "pl",
+              "name": "Fabryczna / Wagonowa",
+              "number": 15036,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.112726,
+                "lng": 16.988762
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499488",
+              "brandUid": "pl",
+              "name": "Plac Legionów",
+              "number": 15037,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.104413,
+                "lng": 17.022536
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499528",
+              "brandUid": "pl",
+              "name": "Świdnicka / Piłsudskiego (Hotel Scandic)",
+              "number": 15038,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.101319,
+                "lng": 17.028535
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 11,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591976,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591721,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591205,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591042,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590984,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590857,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590355,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590003,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 12
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12499561",
+              "brandUid": "pl",
+              "name": "Kościuszki / Pułaskiego",
+              "number": 15039,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.1004,
+                "lng": 17.045083
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592291,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499586",
+              "brandUid": "pl",
+              "name": "Plac Powstańców Warszawy (Muzeum Narodowe)",
+              "number": 15040,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110001,
+                "lng": 17.047736
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592423,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592285,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592130,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591138,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591116,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590364,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590152,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499606",
+              "brandUid": "pl",
+              "name": "Kościuszki / Komuny Paryskiej / Zgodna",
+              "number": 15041,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.098959,
+                "lng": 17.051519
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592386,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592126,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591782,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591679,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591265,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591143,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590556,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590409,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590275,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590202,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12499641",
+              "brandUid": "pl",
+              "name": "Traugutta / Pułaskiego",
+              "number": 15042,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.104571,
+                "lng": 17.048102
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592352,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592301,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592296,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592142,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592116,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592068,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591026,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590549,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590218,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590103,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12500063",
+              "brandUid": "pl",
+              "name": "Stacyjna (Dworzec Mikołajów)",
+              "number": 15043,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.115354,
+                "lng": 16.998732
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592415,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591710,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591656,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590926,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590570,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500088",
+              "brandUid": "pl",
+              "name": "Plac Strzegomski / Poznańska",
+              "number": 15044,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113703,
+                "lng": 17.006287
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591724,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500129",
+              "brandUid": "pl",
+              "name": "Zachodnia / Poznańska",
+              "number": 15045,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.117668,
+                "lng": 17.007137
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592280,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500152",
+              "brandUid": "pl",
+              "name": "Drobnera / Dubois",
+              "number": 15046,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.117032,
+                "lng": 17.033499
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 16,
+                "freeRacks": 11,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592629,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592247,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591462,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590746,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590713,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500181",
+              "brandUid": "pl",
+              "name": "Poniatowskiego / Oleśnicka",
+              "number": 15047,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.121308,
+                "lng": 17.043077
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500203",
+              "brandUid": "pl",
+              "name": "Nowowiejska / Wyszyńskiego",
+              "number": 15048,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.122424,
+                "lng": 17.052013
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592367,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592263,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592137,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592074,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590568,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590294,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500217",
+              "brandUid": "pl",
+              "name": "Żeromskiego / Daszyńskiego",
+              "number": 15049,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12566,
+                "lng": 17.050463
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500232",
+              "brandUid": "pl",
+              "name": "Żeromskiego / Kluczborska",
+              "number": 15050,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.122313,
+                "lng": 17.047515
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592497,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591579,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591033,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590758,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590641,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590146,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500254",
+              "brandUid": "pl",
+              "name": "Joliot-Curie (Uwr)",
+              "number": 15051,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110662,
+                "lng": 17.052712
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 16,
+                "freeRacks": 12,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603879,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590485,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590167,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500273",
+              "brandUid": "pl",
+              "name": "Sienkiewicza / Piastowska",
+              "number": 15052,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.115564,
+                "lng": 17.060704
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592483,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592477,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591123,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590927,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590589,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500314",
+              "brandUid": "pl",
+              "name": "Sienkiewicza / Wyszyńskiego",
+              "number": 15053,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.116822,
+                "lng": 17.051845
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591863,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591813,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500340",
+              "brandUid": "pl",
+              "name": "Plac Grunwaldzki / Polaka",
+              "number": 15054,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110415,
+                "lng": 17.055591
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 16,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592499,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591639,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591565,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591509,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591196,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591162,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590922,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590876,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590707,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500370",
+              "brandUid": "pl",
+              "name": "Wróblewskiego (Teki)",
+              "number": 15055,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.10411,
+                "lng": 17.084711
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 16,
+                "freeRacks": 16,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500399",
+              "brandUid": "pl",
+              "name": "Komandorska / Sanocka",
+              "number": 15056,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.094653,
+                "lng": 17.026775
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603926,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592792,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592720,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592033,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591981,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591747,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591555,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591386,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591073,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590586,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590489,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500421",
+              "brandUid": "pl",
+              "name": "Ślężna / Kamienna (Uniw. Ekonomiczny)",
+              "number": 15057,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.089842,
+                "lng": 17.028225
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592457,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592363,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592123,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591952,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590783,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590755,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590696,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590604,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590036,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 80
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12500454",
+              "brandUid": "pl",
+              "name": "Oporów (pętla tramwajowa)",
+              "number": 15058,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08451,
+                "lng": 16.97223
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592319,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592308,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592004,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591971,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591820,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590052,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 16
+                },
+                {
+                  "number": 590002,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 24
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12500478",
+              "brandUid": "pl",
+              "name": "Zaporoska / Gajowicka",
+              "number": 15059,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.097209,
+                "lng": 17.013967
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592472,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500501",
+              "brandUid": "pl",
+              "name": "Traugutta / Kościuszki",
+              "number": 15060,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.097147,
+                "lng": 17.056251
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592232,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592136,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591946,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591801,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590792,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590618,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500523",
+              "brandUid": "pl",
+              "name": "Nowowiejska / Górnickiego",
+              "number": 15061,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.119311,
+                "lng": 17.056784
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592007,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591499,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591230,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590862,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500551",
+              "brandUid": "pl",
+              "name": "Plac Grunwaldzki (DS Ołówek)",
+              "number": 15062,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113912,
+                "lng": 17.067207
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 16,
+                "freeRacks": 15,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591434,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500568",
+              "brandUid": "pl",
+              "name": "Zaporoska / Grabiszyńska",
+              "number": 15063,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.102117,
+                "lng": 17.013683
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591591,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591573,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590987,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500590",
+              "brandUid": "pl",
+              "name": "Grabiszyńska / Stalowa",
+              "number": 15064,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.099354,
+                "lng": 17.000697
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592548,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592418,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591920,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591596,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591068,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591051,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590554,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500618",
+              "brandUid": "pl",
+              "name": "Krucza / Mielecka / Stalowa",
+              "number": 15065,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.093426,
+                "lng": 17.002893
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591975,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590637,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590348,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500646",
+              "brandUid": "pl",
+              "name": "Aleja Hallera / Mielecka",
+              "number": 15066,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.089315,
+                "lng": 17.001501
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592484,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592369,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591984,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591895,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591886,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591628,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591194,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591134,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591055,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590937,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590643,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590559,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590551,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500681",
+              "brandUid": "pl",
+              "name": "Grochowa / Jemiołowa",
+              "number": 15067,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.095597,
+                "lng": 17.008045
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592740,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592044,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591700,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591646,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591290,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591207,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590909,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590891,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590225,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500737",
+              "brandUid": "pl",
+              "name": "Legnicka / Młodych Techników",
+              "number": 15069,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113141,
+                "lng": 17.012175
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591737,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591371,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591038,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590829,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590513,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590482,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590213,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500780",
+              "brandUid": "pl",
+              "name": "Żelazna / Pereca",
+              "number": 15070,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.098027,
+                "lng": 17.006977
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591617,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590831,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590761,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590537,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590439,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500803",
+              "brandUid": "pl",
+              "name": "Uniwersytet WSB Merito",
+              "number": 15071,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.108016,
+                "lng": 16.983383
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592102,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591802,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591141,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590980,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590754,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590719,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590480,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590357,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590343,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590224,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500815",
+              "brandUid": "pl",
+              "name": "Szewska / Kazimierza Wielkiego ",
+              "number": 15072,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.107494,
+                "lng": 17.033344
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592343,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592175,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592167,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592059,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591994,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590510,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590330,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500854",
+              "brandUid": "pl",
+              "name": "Na Ostatnim Groszu",
+              "number": 15073,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.122636,
+                "lng": 16.975708
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592666,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592490,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592381,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592322,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592286,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591686,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591103,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590530,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590374,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590297,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590138,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500877",
+              "brandUid": "pl",
+              "name": "Grabiszyńska / Magazynierska (Corte Verona)",
+              "number": 15074,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.096659,
+                "lng": 16.988566
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603937,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592930,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592234,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591704,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590664,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590345,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12500893",
+              "brandUid": "pl",
+              "name": "Legnicka / Zachodnia ",
+              "number": 15075,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.117155,
+                "lng": 17.000368
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592496,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592362,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592270,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592267,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591534,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591328,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591148,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591121,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590311,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590149,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590042,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 69
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501008",
+              "brandUid": "pl",
+              "name": "Robotnicza / Fabryczna",
+              "number": 15076,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.112387,
+                "lng": 16.993157
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592281,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591547,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591410,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590917,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590531,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590100,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 71
+                },
+                {
+                  "number": 590043,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 89
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501085",
+              "brandUid": "pl",
+              "name": "Łukasiewicza / Smoluchowskiego (PWr)",
+              "number": 15078,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.108288,
+                "lng": 17.064884
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 28,
+                "freeRacks": 14,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592574,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592397,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591995,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591395,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591209,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590970,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590906,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590897,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590863,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590665,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590341,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590295,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590215,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590158,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501126",
+              "brandUid": "pl",
+              "name": "Kazimierza Wielkiego (Helios)",
+              "number": 15079,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110342,
+                "lng": 17.02601
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 16,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592858,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592297,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591922,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591773,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591517,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591170,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591044,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591015,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590933,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590024,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 52
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501151",
+              "brandUid": "pl",
+              "name": "Drobnera / Plac Bema",
+              "number": 15080,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.117557,
+                "lng": 17.040967
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592098,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591249,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590784,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590617,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590540,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590473,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501174",
+              "brandUid": "pl",
+              "name": "Krzywoustego - Rynek Psie Pole",
+              "number": 15081,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.147339,
+                "lng": 17.11452
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592562,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592111,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592067,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592034,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591669,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591538,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591329,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591199,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591018,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590872,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590844,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590552,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590438,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590248,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590207,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501209",
+              "brandUid": "pl",
+              "name": "Pilczycka / Kozanowska",
+              "number": 15082,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.13699,
+                "lng": 16.966199
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591930,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590895,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590562,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590026,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 29
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501262",
+              "brandUid": "pl",
+              "name": "Aleja Kromera",
+              "number": 15083,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.132259,
+                "lng": 17.065453
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591046,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501283",
+              "brandUid": "pl",
+              "name": "Leśnica - pętla tramwajowa",
+              "number": 15084,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.14502,
+                "lng": 16.872364
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592468,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592405,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592223,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591905,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591784,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591771,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591763,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591325,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590748,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590304,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501303",
+              "brandUid": "pl",
+              "name": "Krzycka / Aleja Karkonoska (Park Południowy)",
+              "number": 15085,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.074992,
+                "lng": 17.007058
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591760,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591164,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590061,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 64
+                },
+                {
+                  "number": 590025,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 75
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501375",
+              "brandUid": "pl",
+              "name": "Mościckiego (stacja kolejowa)",
+              "number": 15086,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.063834,
+                "lng": 17.083366
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592535,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592182,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592054,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591281,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591114,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591081,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590938,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590081,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 39
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501449",
+              "brandUid": "pl",
+              "name": "Żmigrodzka / Broniewskiego",
+              "number": 15094,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.136111,
+                "lng": 17.036262
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592434,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591906,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590976,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590593,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501499",
+              "brandUid": "pl",
+              "name": "Zwycięska / Ołtaszyńska",
+              "number": 15087,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.059458,
+                "lng": 17.006542
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592882,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591765,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590475,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590104,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 46
+                },
+                {
+                  "number": 590069,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 12
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501561",
+              "brandUid": "pl",
+              "name": "Strzegomska / Estońska",
+              "number": 15088,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.111874,
+                "lng": 16.960692
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591135,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590305,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590058,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 31
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501584",
+              "brandUid": "pl",
+              "name": "Świeradowska (Ferio Gaj )",
+              "number": 15089,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.07692,
+                "lng": 17.041439
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592284,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591767,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591368,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590810,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590536,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590487,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590467,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590251,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590067,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 86
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501733",
+              "brandUid": "pl",
+              "name": "Wałbrzyska - pętla tramwajowa",
+              "number": 15090,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.065777,
+                "lng": 16.988575
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592456,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592251,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592109,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591659,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591658,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591641,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591529,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591432,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591322,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591235,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591195,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591166,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590493,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590399,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501772",
+              "brandUid": "pl",
+              "name": "Buforowa - Vivaldiego",
+              "number": 15091,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.051546,
+                "lng": 17.059094
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592635,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592093,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592083,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591288,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591076,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591060,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590836,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590650,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590331,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590268,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501798",
+              "brandUid": "pl",
+              "name": "Pilczycka (Stadion Miejski)",
+              "number": 15092,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.143633,
+                "lng": 16.950712
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592313,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592282,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592253,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592158,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591040,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590689,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590455,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501819",
+              "brandUid": "pl",
+              "name": "Bardzka / Piękna",
+              "number": 15093,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.085034,
+                "lng": 17.04932
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 26,
+                "bookedBikes": 0,
+                "availableBikes": 26,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592770,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592638,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592553,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592500,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592133,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592094,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592028,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591987,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591811,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591584,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591574,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591501,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591379,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591364,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591341,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591300,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590944,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590942,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590782,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590747,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590709,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590644,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590607,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590300,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590291,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590233,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 26
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501841",
+              "brandUid": "pl",
+              "name": "Tyrmanda / Trawowa",
+              "number": 15095,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.100211,
+                "lng": 16.951602
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501859",
+              "brandUid": "pl",
+              "name": "Zatorska / Królewska - pętla MPK",
+              "number": 15096,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.160332,
+                "lng": 17.133683
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592610,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592551,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592394,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591954,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591861,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591691,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591513,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591354,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591264,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590457,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590023,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 49
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12501871",
+              "brandUid": "pl",
+              "name": "Marca Polo (Olimpia Port)",
+              "number": 15097,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.110299,
+                "lng": 17.117854
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 27,
+                "bookedBikes": 0,
+                "availableBikes": 27,
+                "bikeRacks": 8,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592808,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592718,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592544,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592268,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592239,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592178,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592106,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591980,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591885,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591846,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591722,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591684,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591609,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591365,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591211,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591061,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591009,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590985,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590826,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590790,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590711,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590692,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590456,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590273,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590242,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590240,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 27
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501893",
+              "brandUid": "pl",
+              "name": "Osobowicka - pętla tramwajowa",
+              "number": 15098,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.137452,
+                "lng": 16.994705
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592312,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592085,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591217,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590875,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501915",
+              "brandUid": "pl",
+              "name": "Waniliowa / Cynamonowa",
+              "number": 15099,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.17592,
+                "lng": 16.998482
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591766,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12501933",
+              "brandUid": "pl",
+              "name": "Żernicka",
+              "number": 15100,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.123237,
+                "lng": 16.924321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592685,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592674,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592420,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592057,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592037,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591957,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591334,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591289,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591131,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591035,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590879,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590762,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590614,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590287,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590264,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590063,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 21
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "12914436",
+              "brandUid": "pl",
+              "name": "Centrum Handlowe Auchan Bielany",
+              "number": 15252,
+              "placeType": "STATION",
+              "terminalType": "STATION_3G",
+              "geoCoords": {
+                "lat": 51.052723,
+                "lng": 16.968801
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592071,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592061,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591342,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591314,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590837,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590622,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590608,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "12914439",
+              "brandUid": "pl",
+              "name": "Aleja Bielany",
+              "number": 15253,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.048391,
+                "lng": 16.961699
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 22,
+                "bookedBikes": 0,
+                "availableBikes": 22,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592399,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592165,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592024,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591986,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591937,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591926,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591889,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591447,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591367,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591303,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591258,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591077,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591010,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590999,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590995,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590732,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590555,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590408,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590301,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590274,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 22
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16333977",
+              "brandUid": "pl",
+              "name": "Obornicka / Bałtycka",
+              "number": 15101,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.136786,
+                "lng": 17.030368
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 14,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592637,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592385,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592306,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592053,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591947,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591753,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591536,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590990,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590832,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590271,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590135,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16333997",
+              "brandUid": "pl",
+              "name": "Berenta / Kasprowicza",
+              "number": 15102,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.138463,
+                "lng": 17.059804
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591648,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591488,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591326,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591239,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590964,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590739,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590545,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334300",
+              "brandUid": "pl",
+              "name": "Kraszewskiego / Trzebnicka",
+              "number": 15103,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12843,
+                "lng": 17.0363
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592823,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592583,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592196,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591621,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591510,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591343,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591129,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590632,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590575,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590391,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334371",
+              "brandUid": "pl",
+              "name": "Grota-Roweckiego / Parafialna",
+              "number": 15104,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06277,
+                "lng": 17.0321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 35,
+                "bookedBikes": 0,
+                "availableBikes": 35,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603896,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592917,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592617,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592607,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592190,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592079,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592065,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591931,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591848,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591719,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591702,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591685,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591568,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591530,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591503,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591319,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591275,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591220,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591216,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591158,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591146,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591107,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590802,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590778,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590756,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590741,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590684,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590647,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590466,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590361,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590317,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590308,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590267,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590150,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 35
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334518",
+              "brandUid": "pl",
+              "name": "Świeradowska / Krynicka",
+              "number": 15105,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.077147,
+                "lng": 17.046785
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592022,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591910,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591192,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591071,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590627,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590600,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334533",
+              "brandUid": "pl",
+              "name": "Krzywoustego / Korona",
+              "number": 15106,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14035,
+                "lng": 17.08494
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 37,
+                "bookedBikes": 0,
+                "availableBikes": 37,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592783,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592753,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592531,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592525,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592478,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592424,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592290,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592266,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592161,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591988,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591919,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591823,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591796,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591795,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591583,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591457,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591253,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591244,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591232,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591198,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591165,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591108,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591091,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591053,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591002,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590827,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590819,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590788,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590529,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590505,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590498,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590459,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590349,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590266,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590210,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590145,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590110,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 37
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334561",
+              "brandUid": "pl",
+              "name": "Rogowska / Zemska",
+              "number": 15107,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11869,
+                "lng": 16.95336
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591238,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590981,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16334613",
+              "brandUid": "pl",
+              "name": "Hermanowska / Kołobrzeska",
+              "number": 15108,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12353,
+                "lng": 16.95059
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590094,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 98
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "16334773",
+              "brandUid": "pl",
+              "name": "Solskiego / al. Piastów",
+              "number": 15109,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.0775,
+                "lng": 16.96396
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591092,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590027,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 74
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16334924",
+              "brandUid": "pl",
+              "name": "Czekoladowa / Wałbrzyska",
+              "number": 15110,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06404,
+                "lng": 16.97753
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603891,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603883,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592789,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592493,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592428,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592330,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592113,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592026,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591645,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591604,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590653,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590488,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590310,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590119,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590054,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 90
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16334990",
+              "brandUid": "pl",
+              "name": "Tarnogajska / Klimasa",
+              "number": 15111,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08015,
+                "lng": 17.06228
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592411,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591942,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591786,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591775,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591717,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591699,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591500,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591310,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590770,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590410,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335034",
+              "brandUid": "pl",
+              "name": "Opolska / pętla tramwajowa",
+              "number": 15112,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07748,
+                "lng": 17.08405
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592346,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592135,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590420,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335065",
+              "brandUid": "pl",
+              "name": "Graniczna / Strzegomska",
+              "number": 15113,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10702,
+                "lng": 16.94971
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592340,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592273,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592120,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592096,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591256,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591231,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590769,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590660,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590573,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590477,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590452,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590383,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590047,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 86
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335081",
+              "brandUid": "pl",
+              "name": "Żmigrodzka / Marino",
+              "number": 15114,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15013,
+                "lng": 17.02903
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592117,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592017,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591867,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591445,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591180,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591154,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590845,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590791,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590501,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590333,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590071,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 15
+                },
+                {
+                  "number": 590053,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 71
+                },
+                {
+                  "number": 590041,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 17
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335150",
+              "brandUid": "pl",
+              "name": "Kutrzeby / Hubala",
+              "number": 15115,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.056727,
+                "lng": 17.022121
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592203,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592078,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591787,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591693,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591636,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591600,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591139,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590821,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590774,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335230",
+              "brandUid": "pl",
+              "name": "Zwycięska / Agrestowa",
+              "number": 15116,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.0586,
+                "lng": 17.01411
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590143,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335249",
+              "brandUid": "pl",
+              "name": "al. Karkonoska / Jeździecka",
+              "number": 15117,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.061472,
+                "lng": 16.997531
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592641,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592255,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592240,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591944,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591635,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591525,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590912,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590721,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590465,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590328,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590283,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335549",
+              "brandUid": "pl",
+              "name": "Ślężna / Skierniewicka",
+              "number": 15118,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07708,
+                "lng": 17.01824
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603953,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592757,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592576,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592451,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592304,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591829,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591761,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591644,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591512,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591357,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591174,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591011,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590913,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590400,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590131,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590093,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 66
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335560",
+              "brandUid": "pl",
+              "name": "Strzegomska / Rogowska ",
+              "number": 15119,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11059,
+                "lng": 16.95514
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335673",
+              "brandUid": "pl",
+              "name": "Karwińska / Opolska",
+              "number": 15120,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08149,
+                "lng": 17.07693
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592663,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592598,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592124,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591878,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591674,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591627,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591581,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591352,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591243,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591213,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590911,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590786,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590407,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590370,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335708",
+              "brandUid": "pl",
+              "name": "Reymonta / Kleczkowska",
+              "number": 15121,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12695,
+                "lng": 17.02804
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 7,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592527,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592393,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592300,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592269,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591903,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590035,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 60
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335721",
+              "brandUid": "pl",
+              "name": "Młodych Techników",
+              "number": 15122,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.118899,
+                "lng": 17.013477
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592446,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592032,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591948,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591544,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591020,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590811,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590521,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590059,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 78
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16335848",
+              "brandUid": "pl",
+              "name": "Popowicka / Niedźwiedzia",
+              "number": 15123,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.1253,
+                "lng": 16.997218
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 5,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590693,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590413,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335861",
+              "brandUid": "pl",
+              "name": "Lotnicza / Metalowców",
+              "number": 15124,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13258,
+                "lng": 16.95697
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603902,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592488,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592391,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592245,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591427,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591296,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591160,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591153,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590567,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16335991",
+              "brandUid": "pl",
+              "name": "Zaporoska / Wielka / Krucza",
+              "number": 15125,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09431,
+                "lng": 17.01479
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592163,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591912,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591687,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591505,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591336,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591315,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590385,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336016",
+              "brandUid": "pl",
+              "name": "Maślicka / Stodolna",
+              "number": 15126,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15755,
+                "lng": 16.92781
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592087,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591759,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591240,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590479,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590269,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590163,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336454",
+              "brandUid": "pl",
+              "name": "Bystrzycka / Idzikowskiego",
+              "number": 15127,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12658,
+                "lng": 16.95499
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592639,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592600,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592156,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591554,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590440,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590437,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336520",
+              "brandUid": "pl",
+              "name": "al. Kochanowskiego / Śniadeckich ",
+              "number": 15128,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.120068,
+                "lng": 17.077684
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 15,
+                "bookedBikes": 0,
+                "availableBikes": 15,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603958,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592375,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592321,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592081,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591854,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591836,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591756,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591708,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591006,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590936,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590781,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590672,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590550,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590378,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590347,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336553",
+              "brandUid": "pl",
+              "name": "al. Brücknera / Kwidzyńska",
+              "number": 15129,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13198,
+                "lng": 17.07945
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592727,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592672,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592664,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592373,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591999,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591935,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591915,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591817,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591677,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591398,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591161,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591128,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591080,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590978,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590828,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590645,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590431,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590366,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336577",
+              "brandUid": "pl",
+              "name": "Kozanowska / Pilczycka",
+              "number": 15130,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13252,
+                "lng": 16.97377
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336716",
+              "brandUid": "pl",
+              "name": "Pilczycka / Koszykarska",
+              "number": 15131,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.140713,
+                "lng": 16.958199
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591191,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590004,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 40
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16336733",
+              "brandUid": "pl",
+              "name": "al. Jana III Sobieskiego / stacja kolejowa",
+              "number": 15132,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.150227,
+                "lng": 17.118549
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592365,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592293,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591979,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591111,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590842,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590151,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336907",
+              "brandUid": "pl",
+              "name": "Kamieńskiego / Jutrosińska",
+              "number": 15133,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.147082,
+                "lng": 17.042321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591698,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591672,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591362,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591115,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590967,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590870,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590744,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16336983",
+              "brandUid": "pl",
+              "name": "Semaforowa",
+              "number": 15134,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.05927,
+                "lng": 17.07877
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337122",
+              "brandUid": "pl",
+              "name": "Olszewskiego / Spółdzielcza",
+              "number": 15135,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10209,
+                "lng": 17.10168
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603903,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592426,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592407,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592302,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592152,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591962,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591825,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591563,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591526,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591335,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591298,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591259,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591185,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591104,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590871,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590798,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590515,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590499,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337271",
+              "brandUid": "pl",
+              "name": "Olszewskiego, pętla tramwajowa",
+              "number": 15136,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.101428,
+                "lng": 17.108523
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 6,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591218,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590777,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337352",
+              "brandUid": "pl",
+              "name": "Bacciarellego",
+              "number": 15137,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.105578,
+                "lng": 17.111316
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592112,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591991,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591821,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591746,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591344,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591340,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590996,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590921,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590808,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590652,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590381,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590060,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 63
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16337500",
+              "brandUid": "pl",
+              "name": "al. Kochanowskiego / Kopernika",
+              "number": 15138,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11514,
+                "lng": 17.07436
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591866,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591745,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591673,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591569,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590977,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337589",
+              "brandUid": "pl",
+              "name": "Bałtycka / Żmigrodzka",
+              "number": 15139,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13959,
+                "lng": 17.03216
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591633,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591586,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591001,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590859,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590288,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337736",
+              "brandUid": "pl",
+              "name": "Bezpieczna / Obornicka",
+              "number": 15140,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14156,
+                "lng": 17.02587
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591897,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591619,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337802",
+              "brandUid": "pl",
+              "name": "Drzewieckiego / Dedala",
+              "number": 15141,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.125652,
+                "lng": 16.968627
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 20,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592348,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592207,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591852,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591655,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591531,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591203,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591017,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590890,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590640,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590416,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590369,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590231,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590021,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 29
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16337827",
+              "brandUid": "pl",
+              "name": "Ślężna / pętla tramwajowa",
+              "number": 15142,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.072302,
+                "lng": 17.012384
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591927,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590638,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16337888",
+              "brandUid": "pl",
+              "name": "Mościckiego / Chińska ",
+              "number": 15143,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.05909,
+                "lng": 17.08687
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592765,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592449,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592372,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592236,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592048,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591959,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591871,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591850,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591562,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591511,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591229,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591088,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591085,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590896,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590825,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590449,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590425,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590406,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590134,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590049,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 93
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 20
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16338002",
+              "brandUid": "pl",
+              "name": "Krakowska / Leroy Merlin",
+              "number": 15144,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09053,
+                "lng": 17.06373
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603038,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592894,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592408,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592060,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591705,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591543,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591147,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591021,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590867,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590726,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590492,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590390,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590241,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338057",
+              "brandUid": "pl",
+              "name": "Koszarowa / UWr",
+              "number": 15145,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14128,
+                "lng": 17.06613
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 16,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592665,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592552,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592402,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591934,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591870,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591175,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338073",
+              "brandUid": "pl",
+              "name": "Sołtysowicka / Redycka",
+              "number": 15146,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14905,
+                "lng": 17.07565
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 31,
+                "bookedBikes": 0,
+                "availableBikes": 31,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592817,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592652,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592512,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592360,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592356,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592119,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592084,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592082,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592049,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591808,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591792,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591696,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591668,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591549,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591260,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591145,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591048,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590848,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590796,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590752,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590691,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590623,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590572,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590503,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590491,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590470,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590356,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590270,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590169,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590120,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 31
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338172",
+              "brandUid": "pl",
+              "name": "al. Poprzeczna / stacja kolejowa",
+              "number": 15147,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.143302,
+                "lng": 17.08146
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592532,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592374,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592264,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591516,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590725,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590306,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338219",
+              "brandUid": "pl",
+              "name": "Przyjaźni / Karkonoska",
+              "number": 15148,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06841,
+                "lng": 17.00399
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591714,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591713,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590605,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590451,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590206,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590133,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338267",
+              "brandUid": "pl",
+              "name": "Przyjaźni",
+              "number": 15149,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06667,
+                "lng": 16.99435
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591090,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338338",
+              "brandUid": "pl",
+              "name": "Konduktorska",
+              "number": 15150,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.06628,
+                "lng": 17.05825
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592438,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591989,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591857,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591853,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591595,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591546,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590697,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590539,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590323,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590144,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338382",
+              "brandUid": "pl",
+              "name": "Jerzmanowska",
+              "number": 15151,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.120913,
+                "lng": 16.876257
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592640,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592613,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592090,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591078,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590337,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590126,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338506",
+              "brandUid": "pl",
+              "name": "Nyska / Piękna",
+              "number": 15152,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.084669,
+                "lng": 17.053112
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592063,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591003,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590957,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590763,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590630,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338527",
+              "brandUid": "pl",
+              "name": "pl. Powstańców Wielkopolskich",
+              "number": 15153,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12469,
+                "lng": 17.03488
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 8,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591514,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590496,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338671",
+              "brandUid": "pl",
+              "name": "pl. Staszica",
+              "number": 15154,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12266,
+                "lng": 17.02995
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 10,
+                "freeRacks": 3,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592414,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592013,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591630,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591380,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591257,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590824,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590624,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338780",
+              "brandUid": "pl",
+              "name": "Jedności Narodowej / Wyszyńskiego",
+              "number": 15155,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12814,
+                "lng": 17.05477
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591407,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591133,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338963",
+              "brandUid": "pl",
+              "name": "Mickiewicza / pętla tramwajowa",
+              "number": 15156,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11397,
+                "lng": 17.10395
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592366,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591556,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591350,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591234,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590773,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590715,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590127,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16338984",
+              "brandUid": "pl",
+              "name": "al. Armii Krajowej / Borowska",
+              "number": 15157,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08361,
+                "lng": 17.03523
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590949,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590362,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339044",
+              "brandUid": "pl",
+              "name": "Gliniana / Gajowa",
+              "number": 15158,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09152,
+                "lng": 17.04033
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592773,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592669,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592390,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591734,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591729,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591701,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590441,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590382,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590040,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 48
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16339087",
+              "brandUid": "pl",
+              "name": "Kamienna / Tomaszowska",
+              "number": 15159,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.087764,
+                "lng": 17.039318
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592392,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591940,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339118",
+              "brandUid": "pl",
+              "name": "al. Armii Krajowej / Bardzka",
+              "number": 15160,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08283,
+                "lng": 17.04824
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 29,
+                "bookedBikes": 0,
+                "availableBikes": 29,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603945,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603695,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592820,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592729,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592589,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592521,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592432,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592320,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592317,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592260,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592243,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592097,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592046,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591996,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591879,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591757,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591723,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591624,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591608,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591567,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591489,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590424,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590352,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590322,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590315,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590292,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590282,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590161,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590137,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 29
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339202",
+              "brandUid": "pl",
+              "name": "Hallera / Odkrywców",
+              "number": 15161,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09126,
+                "lng": 16.98581
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 8,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592928,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592398,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591768,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591324,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339233",
+              "brandUid": "pl",
+              "name": "Skarbowców / Wietrzna",
+              "number": 15162,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07329,
+                "lng": 16.99485
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603935,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592147,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592128,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592075,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590528,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590371,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339243",
+              "brandUid": "pl",
+              "name": "Racławicka / Rymarska",
+              "number": 15163,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08022,
+                "lng": 16.99467
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592501,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339272",
+              "brandUid": "pl",
+              "name": "Bajana / Szybowcowa",
+              "number": 15164,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13004,
+                "lng": 16.96605
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592709,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339339",
+              "brandUid": "pl",
+              "name": "Strachocińska / Wieśniacza",
+              "number": 15165,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10666,
+                "lng": 17.14298
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 4,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592450,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591640,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590584,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339373",
+              "brandUid": "pl",
+              "name": "Księgarska / Dekarska / Zduńska",
+              "number": 15166,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.17759,
+                "lng": 17.01588
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592498,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592170,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591794,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591263,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591204,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590681,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590585,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590526,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339408",
+              "brandUid": "pl",
+              "name": "Piękna",
+              "number": 15168,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.085272,
+                "lng": 17.05681
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592459,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592056,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591200,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591032,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339429",
+              "brandUid": "pl",
+              "name": "al. Armii Krajowej / Tarnogajska",
+              "number": 15169,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.083551,
+                "lng": 17.060519
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592913,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592786,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592480,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592462,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591966,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591508,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591069,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590834,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590639,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590542,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590516,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590415,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339489",
+              "brandUid": "pl",
+              "name": "Prochowicka / Dolnobrzeska",
+              "number": 15170,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15127,
+                "lng": 16.86564
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 6,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591225,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591172,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590795,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590064,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16339547",
+              "brandUid": "pl",
+              "name": "Boguszowska / Kosmonautów",
+              "number": 15171,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14395,
+                "lng": 16.89012
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591909,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591883,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591036,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590882,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590200,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339566",
+              "brandUid": "pl",
+              "name": "Popowicka / Rysia",
+              "number": 15172,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.127192,
+                "lng": 16.991832
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592487,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592246,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590514,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590228,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339637",
+              "brandUid": "pl",
+              "name": "Kosmonautów / Glinianki / WUWA2",
+              "number": 15173,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13884,
+                "lng": 16.93191
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 10,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590461,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590232,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16339816",
+              "brandUid": "pl",
+              "name": "Wilanowska",
+              "number": 15174,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15509,
+                "lng": 17.13249
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 19,
+                "bookedBikes": 0,
+                "availableBikes": 19,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592642,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592105,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592020,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591843,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591622,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591557,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591502,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591283,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591250,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591228,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591212,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591119,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590800,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590613,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590474,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590463,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590262,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590249,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590078,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 24
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16339872",
+              "brandUid": "pl",
+              "name": "Okulickiego",
+              "number": 15175,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.160517,
+                "lng": 17.12231
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592590,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592157,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591830,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590353,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340287",
+              "brandUid": "pl",
+              "name": "Poleska / Litewska",
+              "number": 15176,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.142323,
+                "lng": 17.127246
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592455,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592409,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591831,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591590,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590994,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590716,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590471,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590376,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590329,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590012,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 18
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340385",
+              "brandUid": "pl",
+              "name": "Bacciarellego / pętla autobusowa",
+              "number": 15177,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10224,
+                "lng": 17.11645
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592713,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592476,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592445,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592422,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592387,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592289,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592279,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592250,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592230,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591896,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591799,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591783,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591652,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591214,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591050,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590869,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590767,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590736,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590731,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590533,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590504,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590244,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590157,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340416",
+              "brandUid": "pl",
+              "name": "Średzka / Dolnobrzeska ",
+              "number": 15178,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14597,
+                "lng": 16.86692
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 10,
+                "freeRacks": 10,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340448",
+              "brandUid": "pl",
+              "name": "Miłoszycka / Swojczycka ",
+              "number": 15179,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11464,
+                "lng": 17.13042
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592643,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592518,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592461,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592377,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591928,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591881,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591748,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591718,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591043,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590928,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590706,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590633,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590324,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340523",
+              "brandUid": "pl",
+              "name": "Stabłowicka / Główna ",
+              "number": 15180,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.16322,
+                "lng": 16.89648
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 22,
+                "bookedBikes": 0,
+                "availableBikes": 22,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592633,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592442,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592368,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592275,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592148,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592114,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591951,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591587,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591157,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591122,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591109,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591086,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591007,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590486,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590436,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590435,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590418,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590332,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590164,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590118,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590088,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 34
+                },
+                {
+                  "number": 590084,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 42
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 20
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340542",
+              "brandUid": "pl",
+              "name": "Wojanowska / Arbuzowa ",
+              "number": 15181,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15435,
+                "lng": 16.89888
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 20,
+                "bookedBikes": 0,
+                "availableBikes": 20,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592758,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592378,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592307,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592191,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592155,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592131,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591916,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591678,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591577,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591476,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591375,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591233,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591178,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591102,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591101,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590986,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590855,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590787,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590561,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590062,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 58
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 19
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340561",
+              "brandUid": "pl",
+              "name": "Osobowicka / Ostrowska",
+              "number": 15182,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14382,
+                "lng": 16.98789
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 3,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592549,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592511,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592351,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592283,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591877,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591770,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591712,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591227,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591079,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590959,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590740,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590658,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590595,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590557,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590490,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590321,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340573",
+              "brandUid": "pl",
+              "name": "Kiełczowska",
+              "number": 15183,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14574,
+                "lng": 17.13493
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592388,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591869,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591703,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591625,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591592,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591515,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591487,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591014,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590958,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590929,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590894,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590670,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590412,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340595",
+              "brandUid": "pl",
+              "name": "Gorlicka / Litewska",
+              "number": 15184,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.141797,
+                "lng": 17.123711
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 34,
+                "bookedBikes": 0,
+                "availableBikes": 34,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592779,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592646,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592619,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592447,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592425,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592328,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592272,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592244,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592188,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591936,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591858,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591736,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591663,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591572,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591490,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591392,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591363,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591333,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591074,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591039,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590931,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590816,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590768,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590730,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590625,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590447,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590395,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590272,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590223,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590216,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590160,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590095,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 26
+                },
+                {
+                  "number": 590020,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 37
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 32
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340625",
+              "brandUid": "pl",
+              "name": "Kasprowicza / Syrokomli",
+              "number": 15185,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.137247,
+                "lng": 17.048546
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590453,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340665",
+              "brandUid": "pl",
+              "name": "Paprotna / Obornicka, zajezdnia MPK",
+              "number": 15186,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.148528,
+                "lng": 17.020477
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 6,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592915,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592441,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590887,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590113,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590010,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 83
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340698",
+              "brandUid": "pl",
+              "name": "Kosmonautów / Fieldorfa, szpital wojewódzki",
+              "number": 15187,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14221,
+                "lng": 16.90591
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340717",
+              "brandUid": "pl",
+              "name": "Stabłowicka ",
+              "number": 15188,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.171074,
+                "lng": 16.902364
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340737",
+              "brandUid": "pl",
+              "name": "Mrągowska / Rolna",
+              "number": 15189,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.149606,
+                "lng": 16.938033
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592503,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591126,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590877,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590014,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 40
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340824",
+              "brandUid": "pl",
+              "name": "Partyzantów / Okrzei",
+              "number": 15190,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.109457,
+                "lng": 17.097924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 33,
+                "bookedBikes": 0,
+                "availableBikes": 33,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592545,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592460,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592287,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592261,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592204,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592072,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591990,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591833,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591772,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591660,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591647,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591582,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591576,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591545,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591535,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591524,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591506,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591132,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591100,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591062,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590930,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590804,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590704,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590682,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590667,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590661,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590648,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590576,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590445,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590427,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590377,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590153,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 33
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340849",
+              "brandUid": "pl",
+              "name": "Hubska / Prudnicka",
+              "number": 15191,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.089572,
+                "lng": 17.045321
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603951,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591725,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591716,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591676,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591137,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591052,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340867",
+              "brandUid": "pl",
+              "name": "Jagodzińska / Buforowa",
+              "number": 15192,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.058564,
+                "lng": 17.056696
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 23,
+                "bookedBikes": 0,
+                "availableBikes": 23,
+                "bikeRacks": 4,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603960,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592427,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592259,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592139,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592129,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592086,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592040,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592031,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591670,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591588,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591320,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591308,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591247,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591125,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591063,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590935,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590720,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590548,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590320,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590252,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590056,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 13
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 22
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16340877",
+              "brandUid": "pl",
+              "name": "Kołłątaja / Podwale",
+              "number": 15193,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103854,
+                "lng": 17.03678
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591776,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591749,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591528,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590753,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340895",
+              "brandUid": "pl",
+              "name": "Opolska / Siemianowicka",
+              "number": 15194,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.071275,
+                "lng": 17.090906
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590634,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340965",
+              "brandUid": "pl",
+              "name": "Piaskowa / św. Ducha",
+              "number": 15195,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.11289,
+                "lng": 17.03971
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 9,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591804,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591539,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591460,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591442,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590793,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590597,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16340992",
+              "brandUid": "pl",
+              "name": "Klecińska / Duńska",
+              "number": 15196,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.109433,
+                "lng": 16.969097
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592134,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591932,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591671,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591637,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590950,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590881,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590668,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16341011",
+              "brandUid": "pl",
+              "name": "pl. Orląt Lwowskich",
+              "number": 15197,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.10823,
+                "lng": 17.02138
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 17,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592563,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592238,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592030,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591862,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591739,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590856,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590839,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590316,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590296,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590008,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 25
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "16341025",
+              "brandUid": "pl",
+              "name": "Komandorska / Kamienna",
+              "number": 15198,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09009,
+                "lng": 17.0235
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592469,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592150,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591845,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591498,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590710,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590587,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590245,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16341036",
+              "brandUid": "pl",
+              "name": "Wrocław Stadion, stacja kolejowa",
+              "number": 15199,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13673,
+                "lng": 16.941433
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 6,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590220,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "16341102",
+              "brandUid": "pl",
+              "name": "Wrocław Leśnica, stacja kolejowa",
+              "number": 15200,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14323,
+                "lng": 16.86627
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590066,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 30
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "27523182",
+              "brandUid": "pl",
+              "name": "Grota-Roweckiego/Iwaszkiewicza",
+              "number": 15255,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.05687,
+                "lng": 17.03236
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591993,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591961,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591682,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590115,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27523205",
+              "brandUid": "pl",
+              "name": "Kowalska/Lechitów",
+              "number": 15256,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13197,
+                "lng": 17.11071
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27523212",
+              "brandUid": "pl",
+              "name": "Kamieńskiego",
+              "number": 15257,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.15472,
+                "lng": 17.04376
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592736,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592009,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590045,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 78
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "27524242",
+              "brandUid": "pl",
+              "name": "Lubelska/Łukowska",
+              "number": 15258,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.165419,
+                "lng": 16.920266
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 18,
+                "bookedBikes": 0,
+                "availableBikes": 18,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592384,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592277,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592265,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592104,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591711,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591520,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591359,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591302,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591224,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590880,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590760,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590734,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590729,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590564,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590373,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590277,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590155,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 18
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524256",
+              "brandUid": "pl",
+              "name": "Kwidzyńska pętla",
+              "number": 15259,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12776,
+                "lng": 17.10254
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592421,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592288,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592089,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591810,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591657,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591623,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591566,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591374,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591237,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591024,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590914,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590902,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590611,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590394,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590226,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590204,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524262",
+              "brandUid": "pl",
+              "name": "Rakowiecka",
+              "number": 15260,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09761,
+                "lng": 17.06855
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592929,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592470,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592332,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592069,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592008,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591841,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591793,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591738,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591370,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591299,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591222,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591215,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591176,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591045,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590900,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590813,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590794,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590785,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590387,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590238,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590205,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 21
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524326",
+              "brandUid": "pl",
+              "name": "Klecińska (Wrocław Grabiszyn)",
+              "number": 15263,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09724,
+                "lng": 16.97512
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 0,
+                "bookedBikes": 0,
+                "availableBikes": 0,
+                "bikeRacks": 6,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [],
+              "bikeTypes": [],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524338",
+              "brandUid": "pl",
+              "name": "Sukielicka / Rogowska",
+              "number": 15264,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.118185,
+                "lng": 16.946011
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 17,
+                "bookedBikes": 0,
+                "availableBikes": 17,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592888,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592777,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592653,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591992,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591982,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591898,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591819,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591762,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591667,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591614,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591585,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591167,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590765,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590417,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590360,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590258,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590123,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 17
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524348",
+              "brandUid": "pl",
+              "name": "Kozanowska/Pałucka",
+              "number": 15265,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13863,
+                "lng": 16.97735
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592897,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592454,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592276,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592233,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592029,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592005,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591933,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591306,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590694,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590610,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590580,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590428,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590338,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590280,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 14
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524358",
+              "brandUid": "pl",
+              "name": "Piławska",
+              "number": 15266,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07236,
+                "lng": 17.04294
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592790,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592529,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592058,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592023,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591758,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591438,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591356,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591012,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590478,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590208,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524366",
+              "brandUid": "pl",
+              "name": "Gorlicka/Stanety",
+              "number": 15267,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.14518,
+                "lng": 17.11679
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592164,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591887,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590687,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590030,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 13
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "27524375",
+              "brandUid": "pl",
+              "name": "3M",
+              "number": 15268,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.1277,
+                "lng": 17.11456
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590885,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524387",
+              "brandUid": "pl",
+              "name": "Gazowa / Międzyleska",
+              "number": 15269,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.07814,
+                "lng": 17.07026
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592315,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592205,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591968,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591809,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591019,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590951,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590946,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590934,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590878,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590817,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590621,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590525,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590500,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590372,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590230,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590148,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 16
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "27524397",
+              "brandUid": "pl",
+              "name": "Bezpieczna/Jugosławiańska",
+              "number": 15270,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.13894,
+                "lng": 17.02028
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592717,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592121,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591868,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591629,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591190,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591057,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590852,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590805,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590666,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590662,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590254,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590077,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 98
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "50389841",
+              "brandUid": "pl",
+              "name": "Amazon WRO2",
+              "number": 15274,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.034956,
+                "lng": 16.950763
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603952,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592050,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591969,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591943,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591900,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591638,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591034,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590979,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590854,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "62573708",
+              "brandUid": "pl",
+              "name": "Gajowicka",
+              "number": 15201,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.085656,
+                "lng": 17.00453
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592807,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590948,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590166,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015132",
+              "brandUid": "pl",
+              "name": "Dalimira/Pęgowska",
+              "number": 15275,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.196906,
+                "lng": 16.974741
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 7,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592021,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591872,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591755,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591603,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591523,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591294,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591169,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591083,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590823,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015172",
+              "brandUid": "pl",
+              "name": "Nowodworska/Strzegomska",
+              "number": 15276,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.114538,
+                "lng": 16.966035
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592798,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591366,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590591,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590005,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 84
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "133015243",
+              "brandUid": "pl",
+              "name": "Kopycińskiego/Drabika",
+              "number": 15278,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.058262,
+                "lng": 17.052487
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 16,
+                "freeRacks": 8,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592444,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592035,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591983,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591964,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591681,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591031,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590596,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590209,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015326",
+              "brandUid": "pl",
+              "name": "Czarnuszkowa/Waniliowa",
+              "number": 15280,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.18079,
+                "lng": 16.999845
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590396,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "133015407",
+              "brandUid": "pl",
+              "name": "Bierutowska",
+              "number": 15281,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.152216,
+                "lng": 17.13217
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592214,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591041,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590201,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590122,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590015,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 73
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "133015775",
+              "brandUid": "pl",
+              "name": "Ziemniaczana/Boiskowa",
+              "number": 15279,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.047299,
+                "lng": 17.091358
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 5,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592453,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592324,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591826,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591680,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590750,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590701,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "138140709",
+              "brandUid": "pl",
+              "name": "Lekarska/Żmigrodzka",
+              "number": 15282,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.161667,
+                "lng": 17.027766
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 10,
+                "freeRacks": 7,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592100,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591029,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590411,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "149870182",
+              "brandUid": "pl",
+              "name": "Starodębowa (Wrocław Pawłowice)",
+              "number": 15283,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.168502,
+                "lng": 17.109124
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 13,
+                "bookedBikes": 0,
+                "availableBikes": 13,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592683,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592177,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591967,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591882,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591522,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591276,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591049,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590246,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590102,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 92
+                },
+                {
+                  "number": 590073,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 93
+                },
+                {
+                  "number": 590070,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 86
+                },
+                {
+                  "number": 590050,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 43
+                },
+                {
+                  "number": 590033,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 100
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "149875085",
+              "brandUid": "pl",
+              "name": "Ibn Siny Awicenny (Wrocław Zachodni)",
+              "number": 15294,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.090573,
+                "lng": 16.950684
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 21,
+                "bookedBikes": 0,
+                "availableBikes": 21,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603888,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592347,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592325,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592145,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592062,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592016,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591956,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591781,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591777,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591631,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591155,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591067,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590960,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590952,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590932,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590766,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590714,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590712,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590657,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590494,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590363,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 21
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "150128867",
+              "brandUid": "pl",
+              "name": "Grapowa",
+              "number": 15295,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.061535,
+                "lng": 17.065717
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 14,
+                "bookedBikes": 0,
+                "availableBikes": 14,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592612,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592448,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592115,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592041,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591918,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591664,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591280,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591261,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591152,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590677,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590547,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590314,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590051,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 68
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 13
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "150129540",
+              "brandUid": "pl",
+              "name": "Wrocław Osobowice",
+              "number": 15296,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.166806,
+                "lng": 16.9975
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 5,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592149,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591807,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591390,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591181,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "518093718",
+              "brandUid": "pl",
+              "name": "Powstańców Śląskich/Orla",
+              "number": 15261,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.08,
+                "lng": 17.00773
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 8,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592052,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591720,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591695,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591642,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591597,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590603,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590234,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520949586",
+              "brandUid": "pl",
+              "name": "Boiskowa / Koreańska",
+              "number": 15308,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.049944,
+                "lng": 17.082919
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592200,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591797,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591540,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591470,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591182,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591094,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590918,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590309,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520950337",
+              "brandUid": "pl",
+              "name": "Swojczycka / Magellana",
+              "number": 15309,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.113559,
+                "lng": 17.120977
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 23,
+                "bookedBikes": 0,
+                "availableBikes": 23,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592793,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592791,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592463,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592412,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592076,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591902,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591824,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591769,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591665,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591651,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591552,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591405,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591318,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591241,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591140,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591082,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591013,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590759,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590723,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590405,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590354,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590350,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590130,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 23
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520951174",
+              "brandUid": "pl",
+              "name": "Jerzmanowska / Adamczewskich",
+              "number": 15310,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12056,
+                "lng": 16.866329
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 10,
+                "freeRacks": 6,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591706,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590818,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590626,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590219,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520951642",
+              "brandUid": "pl",
+              "name": "Jodłowicka",
+              "number": 15311,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.169936,
+                "lng": 16.896987
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592162,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591788,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591754,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591518,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591113,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590733,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590606,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590085,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 33
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "520952092",
+              "brandUid": "pl",
+              "name": "Wrocław Żerniki (stacja kolejowa)",
+              "number": 15312,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.12645,
+                "lng": 16.91389
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591550,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591443,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591301,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591208,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591065,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590546,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590497,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590132,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "520952430",
+              "brandUid": "pl",
+              "name": "Międzyrzecka",
+              "number": 15313,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.09501,
+                "lng": 17.080458
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 10,
+                "freeRacks": 9,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592410,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543289001",
+              "brandUid": "pl",
+              "name": "Wrocław Wojnów, Przy Torze (przystanek kolejowy)",
+              "number": 15323,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.103202,
+                "lng": 17.157738
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592754,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592506,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592189,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592064,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591602,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591561,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591312,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591089,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543289561",
+              "brandUid": "pl",
+              "name": "Awicenny",
+              "number": 15324,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.081686,
+                "lng": 16.956292
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592728,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592604,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592440,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592416,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592295,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592254,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592242,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592110,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592080,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591955,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591815,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591735,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591372,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591219,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591093,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591072,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590955,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590910,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590905,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590619,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590541,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590379,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590159,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590129,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543290242",
+              "brandUid": "pl",
+              "name": "Port Lotniczy",
+              "number": 15325,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.110345,
+                "lng": 16.880269
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 2,
+                "bookedBikes": 0,
+                "availableBikes": 2,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590590,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590398,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543290642",
+              "brandUid": "pl",
+              "name": "Wrocław Wojszyce (przystanek kolejowy)",
+              "number": 15326,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.068934,
+                "lng": 17.032088
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 3,
+                "bookedBikes": 0,
+                "availableBikes": 3,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592396,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591750,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591496,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 3
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543291005",
+              "brandUid": "pl",
+              "name": "Marszowicka",
+              "number": 15327,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.16525,
+                "lng": 16.881418
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592419,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592400,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591347,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591245,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590263,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543291628",
+              "brandUid": "pl",
+              "name": "Hala Stulecia",
+              "number": 15328,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.107838,
+                "lng": 17.073909
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592811,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592658,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591963,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591731,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591279,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591193,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591142,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590764,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590518,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590506,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590289,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590128,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 12
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "543292626",
+              "brandUid": "pl",
+              "name": "Ułańska",
+              "number": 15330,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.054164,
+                "lng": 17.012027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592824,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592554,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591816,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591189,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591004,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590393,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544530233",
+              "brandUid": "pl",
+              "name": "Akademia Wojsk Lądowych",
+              "number": 15338,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.141921,
+                "lng": 17.055193
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591818,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591779,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590797,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590629,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590538,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "558803475",
+              "brandUid": "pl",
+              "name": "BIKE 591106",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273324,
+                "lng": 21.027082
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591106,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "558810060",
+              "brandUid": "pl",
+              "name": "BIKE 591970",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.025782
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591970,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "559097857",
+              "brandUid": "pl",
+              "name": "BIKE 591800",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273502,
+                "lng": 21.027164
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591800,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "560086797",
+              "brandUid": "pl",
+              "name": "BIKE 592588",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273422,
+                "lng": 21.027096
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592588,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561390053",
+              "brandUid": "pl",
+              "name": "BIKE 590214",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273373,
+                "lng": 21.026798
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590214,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561390569",
+              "brandUid": "pl",
+              "name": "BIKE 590156",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272991,
+                "lng": 21.026729
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590156,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561391033",
+              "brandUid": "pl",
+              "name": "BIKE 592596",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.026744
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592596,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561393811",
+              "brandUid": "pl",
+              "name": "BIKE 592924",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273244,
+                "lng": 21.026802
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561394558",
+              "brandUid": "pl",
+              "name": "BIKE 592797",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.2732,
+                "lng": 21.026996
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592797,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561394677",
+              "brandUid": "pl",
+              "name": "BIKE 592938",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273138,
+                "lng": 21.02666
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592938,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561397199",
+              "brandUid": "pl",
+              "name": "BIKE 592747",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273267,
+                "lng": 21.02696
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592747,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561397214",
+              "brandUid": "pl",
+              "name": "BIKE 592771",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273209,
+                "lng": 21.027027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592771,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561397371",
+              "brandUid": "pl",
+              "name": "BIKE 592636",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273324,
+                "lng": 21.027149
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592636,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398354",
+              "brandUid": "pl",
+              "name": "BIKE 592831",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27316,
+                "lng": 21.026862
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592831,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398362",
+              "brandUid": "pl",
+              "name": "BIKE 592895",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273293,
+                "lng": 21.026807
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592895,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398368",
+              "brandUid": "pl",
+              "name": "BIKE 592814",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273302,
+                "lng": 21.026924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592814,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398375",
+              "brandUid": "pl",
+              "name": "BIKE 592796",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273138,
+                "lng": 21.026716
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592796,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398379",
+              "brandUid": "pl",
+              "name": "BIKE 592174",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.2732,
+                "lng": 21.026827
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592174,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398386",
+              "brandUid": "pl",
+              "name": "BIKE 592900",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273093,
+                "lng": 21.026984
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592900,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398388",
+              "brandUid": "pl",
+              "name": "BIKE 592887",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273413,
+                "lng": 21.026676
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592887,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398396",
+              "brandUid": "pl",
+              "name": "BIKE 592921",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273387,
+                "lng": 21.026773
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592921,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398406",
+              "brandUid": "pl",
+              "name": "BIKE 592224",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273316,
+                "lng": 21.026856
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592224,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398417",
+              "brandUid": "pl",
+              "name": "BIKE 592763",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273307,
+                "lng": 21.026727
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592763,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398427",
+              "brandUid": "pl",
+              "name": "BIKE 592939",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273111,
+                "lng": 21.026862
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592939,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398437",
+              "brandUid": "pl",
+              "name": "BIKE 592925",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27328,
+                "lng": 21.026904
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398443",
+              "brandUid": "pl",
+              "name": "BIKE 592864",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273071,
+                "lng": 21.026967
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592864,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398454",
+              "brandUid": "pl",
+              "name": "BIKE 592774",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273142,
+                "lng": 21.026924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592774,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398468",
+              "brandUid": "pl",
+              "name": "BIKE 592670",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273187,
+                "lng": 21.027027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592670,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398474",
+              "brandUid": "pl",
+              "name": "BIKE 592940",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273062,
+                "lng": 21.026978
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592940,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398481",
+              "brandUid": "pl",
+              "name": "BIKE 592712",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.027047
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592712,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398491",
+              "brandUid": "pl",
+              "name": "BIKE 592923",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273151,
+                "lng": 21.026913
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592923,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398495",
+              "brandUid": "pl",
+              "name": "BIKE 592624",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273111,
+                "lng": 21.027038
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592624,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398503",
+              "brandUid": "pl",
+              "name": "BIKE 592901",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273356,
+                "lng": 21.02692
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592901,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398509",
+              "brandUid": "pl",
+              "name": "BIKE 592492",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273436,
+                "lng": 21.027009
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592492,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398526",
+              "brandUid": "pl",
+              "name": "BIKE 592676",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273293,
+                "lng": 21.026849
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592676,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398535",
+              "brandUid": "pl",
+              "name": "BIKE 592877",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273244,
+                "lng": 21.026978
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592877,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398542",
+              "brandUid": "pl",
+              "name": "BIKE 592876",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273316,
+                "lng": 21.026727
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592876,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398548",
+              "brandUid": "pl",
+              "name": "BIKE 592841",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273111,
+                "lng": 21.02714
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592841,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398552",
+              "brandUid": "pl",
+              "name": "BIKE 592815",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273138,
+                "lng": 21.027064
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592815,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398561",
+              "brandUid": "pl",
+              "name": "BIKE 592899",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273227,
+                "lng": 21.026998
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398896",
+              "brandUid": "pl",
+              "name": "BIKE 592764",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273338,
+                "lng": 21.027076
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592764,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561398904",
+              "brandUid": "pl",
+              "name": "BIKE 592701",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273093,
+                "lng": 21.027067
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592701,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561401031",
+              "brandUid": "pl",
+              "name": "BIKE 592768",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27364,
+                "lng": 21.026622
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592768,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561401034",
+              "brandUid": "pl",
+              "name": "BIKE 592922",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273387,
+                "lng": 21.026816
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592922,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561402042",
+              "brandUid": "pl",
+              "name": "BIKE 592184",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272871,
+                "lng": 21.027184
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592184,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561406565",
+              "brandUid": "pl",
+              "name": "BIKE 592715",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273276,
+                "lng": 21.026782
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592715,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561409693",
+              "brandUid": "pl",
+              "name": "BIKE 592721",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273356,
+                "lng": 21.027096
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592721,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "561409708",
+              "brandUid": "pl",
+              "name": "BIKE 592691",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273413,
+                "lng": 21.026862
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592691,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "562450281",
+              "brandUid": "pl",
+              "name": "BIKE 592108",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273169,
+                "lng": 21.026924
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592108,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "562529855",
+              "brandUid": "pl",
+              "name": "BIKE 592625",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273373,
+                "lng": 21.0267
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592625,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "562534340",
+              "brandUid": "pl",
+              "name": "BIKE 592465",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273258,
+                "lng": 21.026716
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592465,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "563732126",
+              "brandUid": "pl",
+              "name": "BIKE 592621",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273542,
+                "lng": 21.026704
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592621,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "563857313",
+              "brandUid": "pl",
+              "name": "BIKE 592213",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273022,
+                "lng": 21.02714
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592213,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "564200611",
+              "brandUid": "pl",
+              "name": "BIKE 592519",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273658,
+                "lng": 21.027253
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592519,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566115884",
+              "brandUid": "pl",
+              "name": "BIKE 591124",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273733,
+                "lng": 21.026769
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591124,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566152377",
+              "brandUid": "pl",
+              "name": "BIKE 592125",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.269311,
+                "lng": 21.026336
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592125,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566161353",
+              "brandUid": "pl",
+              "name": "BIKE 591144",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273329,
+                "lng": 21.027182
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591144,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566389890",
+              "brandUid": "pl",
+              "name": "BIKE 590888",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.2732,
+                "lng": 21.027089
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590888,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566592243",
+              "brandUid": "pl",
+              "name": "BIKE 591790",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.273302,
+                "lng": 21.027211
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591790,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566677463",
+              "brandUid": "pl",
+              "name": "BIKE 29997",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.186156,
+                "lng": 20.850973
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 29997,
+                  "bikeType": "STANDARD_4G",
+                  "battery": 44
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566870157",
+              "brandUid": "pl",
+              "name": "BIKE 590302",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.128827,
+                "lng": 16.89587
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590302,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "566895632",
+              "brandUid": "pl",
+              "name": "BIKE 592211",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.153084,
+                "lng": 16.933566
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592211,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567034187",
+              "brandUid": "pl",
+              "name": "BIKE 590034",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.105711,
+                "lng": 16.962738
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590034,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 56
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567205769",
+              "brandUid": "pl",
+              "name": "BIKE 591037",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.27368,
+                "lng": 21.02674
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591037,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567294782",
+              "brandUid": "pl",
+              "name": "BIKE 590945",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.136271,
+                "lng": 16.895524
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590945,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567442008",
+              "brandUid": "pl",
+              "name": "BIKE 591025",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.179387,
+                "lng": 17.045604
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591025,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567472319",
+              "brandUid": "pl",
+              "name": "BIKE 592338",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.055533,
+                "lng": 16.991081
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592338,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567524279",
+              "brandUid": "pl",
+              "name": "BIKE 591028",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.154231,
+                "lng": 16.927016
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591028,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567540054",
+              "brandUid": "pl",
+              "name": "BIKE 591064",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.177929,
+                "lng": 16.878328
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591064,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567593700",
+              "brandUid": "pl",
+              "name": "BIKE 592073",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272756,
+                "lng": 21.026831
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592073,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567603085",
+              "brandUid": "pl",
+              "name": "BIKE 590257",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.115973,
+                "lng": 16.989622
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590257,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567603706",
+              "brandUid": "pl",
+              "name": "BIKE 590044",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.105569,
+                "lng": 17.043994
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590044,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 27
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567723537",
+              "brandUid": "pl",
+              "name": "BIKE 590072",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.111711,
+                "lng": 17.027127
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590072,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 53
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567736798",
+              "brandUid": "pl",
+              "name": "BIKE 591605",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.123204,
+                "lng": 17.05415
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591605,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567777592",
+              "brandUid": "pl",
+              "name": "BIKE 590893",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.01416,
+                "lng": 16.95746
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567789749",
+              "brandUid": "pl",
+              "name": "BIKE 592678",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.092809,
+                "lng": 16.982056
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592678,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567800641",
+              "brandUid": "pl",
+              "name": "BIKE 603949",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.042933,
+                "lng": 16.942776
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603949,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567816738",
+              "brandUid": "pl",
+              "name": "BIKE 590582",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.05552,
+                "lng": 16.991132
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590582,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567817483",
+              "brandUid": "pl",
+              "name": "BIKE 590577",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.070631,
+                "lng": 16.994879
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590577,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567843175",
+              "brandUid": "pl",
+              "name": "BIKE 591168",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.0966,
+                "lng": 17.009943
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591168,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567858729",
+              "brandUid": "pl",
+              "name": "BIKE 591950",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.192911,
+                "lng": 16.978119
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591950,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567865166",
+              "brandUid": "pl",
+              "name": "BIKE 590074",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.115436,
+                "lng": 17.052866
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590074,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 35
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "567875698",
+              "brandUid": "pl",
+              "name": "BIKE 590293",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.138076,
+                "lng": 16.874902
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590293,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567905551",
+              "brandUid": "pl",
+              "name": "BIKE 590342",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.274511,
+                "lng": 21.026978
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590342,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567950275",
+              "brandUid": "pl",
+              "name": "BIKE 592742",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.146769,
+                "lng": 16.940857
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592742,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567969108",
+              "brandUid": "pl",
+              "name": "BIKE 592299",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.138516,
+                "lng": 17.035514
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592299,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567978034",
+              "brandUid": "pl",
+              "name": "BIKE 591785",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.095071,
+                "lng": 16.96071
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591785,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567978075",
+              "brandUid": "pl",
+              "name": "BIKE 590588",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.068898,
+                "lng": 16.967994
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590588,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568011049",
+              "brandUid": "pl",
+              "name": "BIKE 590048",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.116391,
+                "lng": 16.985292
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590048,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 32
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568015828",
+              "brandUid": "pl",
+              "name": "BIKE 590462",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.028613,
+                "lng": 16.965578
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590462,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568019981",
+              "brandUid": "pl",
+              "name": "BIKE 590450",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103444,
+                "lng": 17.07135
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590450,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568021042",
+              "brandUid": "pl",
+              "name": "BIKE 590090",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.140049,
+                "lng": 16.852759
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590090,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 64
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568049726",
+              "brandUid": "pl",
+              "name": "BIKE 591613",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.154987,
+                "lng": 16.923942
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591613,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568055781",
+              "brandUid": "pl",
+              "name": "BIKE 591744",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.099747,
+                "lng": 17.013491
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591744,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568094079",
+              "brandUid": "pl",
+              "name": "BIKE 592406",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.135978,
+                "lng": 16.928434
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592406,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568094100",
+              "brandUid": "pl",
+              "name": "BIKE 591159",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.136,
+                "lng": 16.9284
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591159,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568094726",
+              "brandUid": "pl",
+              "name": "BIKE 590079",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.105698,
+                "lng": 16.962864
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590079,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 39
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568101482",
+              "brandUid": "pl",
+              "name": "BIKE 590086",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.074471,
+                "lng": 17.016462
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590086,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 96
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568136614",
+              "brandUid": "pl",
+              "name": "BIKE 592012",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.10768,
+                "lng": 17.05081
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592012,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568138918",
+              "brandUid": "pl",
+              "name": "BIKE 592011",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.037404,
+                "lng": 16.956544
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592011,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568141127",
+              "brandUid": "pl",
+              "name": "BIKE 590609",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.172262,
+                "lng": 17.113332
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590609,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568149210",
+              "brandUid": "pl",
+              "name": "BIKE 591307",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.0382,
+                "lng": 16.952179
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591307,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568150279",
+              "brandUid": "pl",
+              "name": "BIKE 591305",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.11132,
+                "lng": 16.996612
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591305,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568151844",
+              "brandUid": "pl",
+              "name": "BIKE 592262",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.056307,
+                "lng": 16.990583
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592262,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568159982",
+              "brandUid": "pl",
+              "name": "BIKE 590904",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.107609,
+                "lng": 17.027606
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590904,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568163463",
+              "brandUid": "pl",
+              "name": "BIKE 591173",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.055484,
+                "lng": 16.991091
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591173,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568164084",
+              "brandUid": "pl",
+              "name": "BIKE 590924",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.113756,
+                "lng": 17.094046
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590924,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568171511",
+              "brandUid": "pl",
+              "name": "BIKE 591056",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103982,
+                "lng": 17.152159
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591056,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568178184",
+              "brandUid": "pl",
+              "name": "BIKE 590125",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110716,
+                "lng": 17.043831
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590125,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568186602",
+              "brandUid": "pl",
+              "name": "BIKE 592784",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.114271,
+                "lng": 17.058748
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592784,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568201271",
+              "brandUid": "pl",
+              "name": "BIKE 591210",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.093627,
+                "lng": 17.024027
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591210,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568204204",
+              "brandUid": "pl",
+              "name": "BIKE 590809",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.060938,
+                "lng": 16.993292
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590809,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568206909",
+              "brandUid": "pl",
+              "name": "BIKE 592514",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.114524,
+                "lng": 17.043751
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592514,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568207250",
+              "brandUid": "pl",
+              "name": "BIKE 590278",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.099022,
+                "lng": 17.028631
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590278,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568208359",
+              "brandUid": "pl",
+              "name": "BIKE 590386",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.117489,
+                "lng": 17.073588
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590386,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568215983",
+              "brandUid": "pl",
+              "name": "BIKE 592627",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.132667,
+                "lng": 17.046957
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592627,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568221896",
+              "brandUid": "pl",
+              "name": "BIKE 592436",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.154142,
+                "lng": 17.066961
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592436,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568222612",
+              "brandUid": "pl",
+              "name": "BIKE 591715",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103613,
+                "lng": 17.070627
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591715,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568224162",
+              "brandUid": "pl",
+              "name": "BIKE 590803",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110409,
+                "lng": 17.109276
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590803,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568227292",
+              "brandUid": "pl",
+              "name": "BIKE 590998",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.118769,
+                "lng": 17.052494
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590998,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568236126",
+              "brandUid": "pl",
+              "name": "BIKE 591348",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.112338,
+                "lng": 16.979502
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591348,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568243054",
+              "brandUid": "pl",
+              "name": "BIKE 592662",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.085893,
+                "lng": 17.014599
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592662,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568243288",
+              "brandUid": "pl",
+              "name": "BIKE 591620",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.053302,
+                "lng": 16.989723
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591620,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568245655",
+              "brandUid": "pl",
+              "name": "BIKE 592019",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110693,
+                "lng": 17.043783
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592019,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568245734",
+              "brandUid": "pl",
+              "name": "BIKE 590820",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.110711,
+                "lng": 17.043751
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590820,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568245956",
+              "brandUid": "pl",
+              "name": "BIKE 591223",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.126529,
+                "lng": 17.058647
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591223,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568246734",
+              "brandUid": "pl",
+              "name": "BIKE 590442",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.1126,
+                "lng": 16.978527
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590442,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568247305",
+              "brandUid": "pl",
+              "name": "BIKE 590484",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.161089,
+                "lng": 16.873661
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590484,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568248492",
+              "brandUid": "pl",
+              "name": "BIKE 591317",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.092733,
+                "lng": 17.034178
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591317,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568252429",
+              "brandUid": "pl",
+              "name": "BIKE 590635",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.071884,
+                "lng": 17.033848
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590635,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568253160",
+              "brandUid": "pl",
+              "name": "BIKE 590097",
+              "number": 0,
+              "placeType": "FREESTANDING_ELECTRIC_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.116413,
+                "lng": 17.068441
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590097,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 83
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
+            },
+            {
+              "uid": "568254736",
+              "brandUid": "pl",
+              "name": "BIKE 590299",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.10796,
+                "lng": 17.078044
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590299,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568254747",
+              "brandUid": "pl",
+              "name": "BIKE 590654",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.10796,
+                "lng": 17.078052
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590654,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255007",
+              "brandUid": "pl",
+              "name": "BIKE 592581",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.134538,
+                "lng": 16.958221
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592581,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255274",
+              "brandUid": "pl",
+              "name": "BIKE 591692",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.159267,
+                "lng": 17.022949
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591692,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255300",
+              "brandUid": "pl",
+              "name": "BIKE 590121",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103622,
+                "lng": 17.070642
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590121,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568255591",
+              "brandUid": "pl",
+              "name": "BIKE 592292",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.146556,
+                "lng": 16.948444
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592292,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568258196",
+              "brandUid": "pl",
+              "name": "BIKE 590327",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.100676,
+                "lng": 17.023834
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590327,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568260530",
+              "brandUid": "pl",
+              "name": "BIKE 591248",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.148187,
+                "lng": 17.079756
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591248,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568263648",
+              "brandUid": "pl",
+              "name": "BIKE 592379",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.103604,
+                "lng": 17.063112
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592379,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568263795",
+              "brandUid": "pl",
+              "name": "BIKE 591345",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 52.272876,
+                "lng": 21.025269
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591345,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568264413",
+              "brandUid": "pl",
+              "name": "BIKE 592192",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.14584,
+                "lng": 17.030066
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592192,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568265577",
+              "brandUid": "pl",
+              "name": "BIKE 591607",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.13312,
+                "lng": 16.991368
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591607,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568265670",
+              "brandUid": "pl",
+              "name": "BIKE 590646",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.098258,
+                "lng": 16.99098
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590646,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568266586",
+              "brandUid": "pl",
+              "name": "BIKE 592318",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.11752,
+                "lng": 17.003473
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592318,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568266669",
+              "brandUid": "pl",
+              "name": "BIKE 590534",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.114516,
+                "lng": 16.990972
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590534,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568267728",
+              "brandUid": "pl",
+              "name": "BIKE 590776",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.060596,
+                "lng": 17.036241
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590776,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Kobierzyce (WRM)",
+          "geoCoords": {
+            "lat": 51.0481,
+            "lng": 17.0025
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "189897679",
+              "brandUid": "pl",
+              "name": "Bielany Wrocławskie Kolejowa P&R",
+              "number": 15302,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.03795,
+                "lng": 16.976374
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603947,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592038,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591958,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591697,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591634,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591346,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590683,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590678,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590566,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590476,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "189898068",
+              "brandUid": "pl",
+              "name": "Wysoka/Nastrojowa",
+              "number": 15303,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.052835,
+                "lng": 17.003956
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592799,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592335,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592103,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591177,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590140,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544488536",
+              "brandUid": "pl",
+              "name": "Wysoka Parkowa / Lipowa",
+              "number": 15339,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.042472,
+                "lng": 17.014538
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592794,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592417,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591730,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591361,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591246,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591022,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590993,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590598,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590423,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590261,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590087,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 61
+                },
+                {
+                  "number": 590055,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 31
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 2
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "544488870",
+              "brandUid": "pl",
+              "name": "Ślęza Parkowa",
+              "number": 15340,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.034473,
+                "lng": 16.993278
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603941,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592870,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592413,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592140,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591618,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591497,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591311,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590519,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590429,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 9
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "567698511",
+              "brandUid": "pl",
+              "name": "BIKE 590384",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.038884,
+                "lng": 16.972551
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590384,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "568252693",
+              "brandUid": "pl",
+              "name": "BIKE 590388",
+              "number": 0,
+              "placeType": "FREESTANDING_BIKE",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.030138,
+                "lng": 16.999451
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 1,
+                "bookedBikes": 0,
+                "availableBikes": 1,
+                "bikeRacks": 0,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 590388,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Wisznia (WRM)",
+          "geoCoords": {
+            "lat": 51.2479,
+            "lng": 17.0442
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "190517322",
+              "brandUid": "pl",
+              "name": "Psary Centrum",
+              "number": 15306,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.185896,
+                "lng": 17.029398
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 9,
+                "bookedBikes": 0,
+                "availableBikes": 9,
+                "bikeRacks": 10,
+                "freeRacks": 1,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592370,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591206,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590961,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590801,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590649,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590512,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590318,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590265,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590107,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 27
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            }
+          ]
+        },
+        {
+          "name": "Kąty Wrocławskie (WRM)",
+          "geoCoords": {
+            "lat": 51.0773,
+            "lng": 16.9133
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "190503572",
+              "brandUid": "pl",
+              "name": "Mokronos Górny PKP",
+              "number": 15304,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.078886,
+                "lng": 16.908149
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 11,
+                "bookedBikes": 0,
+                "availableBikes": 11,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592749,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592730,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592722,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592719,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592703,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592466,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592437,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592429,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592010,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590508,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590106,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 63
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "190512283",
+              "brandUid": "pl",
+              "name": "Smolec",
+              "number": 15305,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.087048,
+                "lng": 16.911286
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 5,
+                "bookedBikes": 0,
+                "availableBikes": 5,
+                "bikeRacks": 10,
+                "freeRacks": 5,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592711,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592091,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591941,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590965,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590799,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 5
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517286",
+              "brandUid": "pl",
+              "name": "Stawowa / Wiśniowa Mokronos Dolny",
+              "number": 15315,
+              "placeType": "STATION",
+              "terminalType": "UNKNOWN",
+              "geoCoords": {
+                "lat": 51.07055,
+                "lng": 16.936889
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 6,
+                "bookedBikes": 0,
+                "availableBikes": 6,
+                "bikeRacks": 10,
+                "freeRacks": 4,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592785,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592752,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592737,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592735,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592706,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590375,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 6
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517297",
+              "brandUid": "pl",
+              "name": "Wrocławska / Spacerowa Mokronos Górny",
+              "number": 15316,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.074457,
+                "lng": 16.919512
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 24,
+                "bookedBikes": 0,
+                "availableBikes": 24,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592878,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592819,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592630,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592565,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592558,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592556,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592524,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592517,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592508,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592036,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591893,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591847,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591000,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590962,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590780,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590659,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590655,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590563,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590524,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590365,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590340,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590276,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590168,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590162,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 24
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Siechnice (WRM)",
+          "geoCoords": {
+            "lat": 51.0334,
+            "lng": 17.1471
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "540517728",
+              "brandUid": "pl",
+              "name": "Osiedlowa/Ciepłownicza Siechnice",
+              "number": 15317,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.025382,
+                "lng": 17.153896
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603964,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603933,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603892,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603890,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603884,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603873,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603866,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590339,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517820",
+              "brandUid": "pl",
+              "name": "Siechnice PKP",
+              "number": 15318,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.038098,
+                "lng": 17.144258
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 4,
+                "bookedBikes": 0,
+                "availableBikes": 4,
+                "bikeRacks": 6,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 591921,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591913,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591593,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591278,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 4
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540517956",
+              "brandUid": "pl",
+              "name": "Siechnice UM",
+              "number": 15319,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.032555,
+                "lng": 17.150512
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 16,
+                "bookedBikes": 0,
+                "availableBikes": 16,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603929,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592632,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592504,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592208,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592006,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591751,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591338,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591183,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590982,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590973,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590742,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590718,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590578,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590335,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590222,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590032,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 52
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 15
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            },
+            {
+              "uid": "540517982",
+              "brandUid": "pl",
+              "name": "Radwanice ul. Kolejowa (Biedronka)",
+              "number": 15322,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.057135,
+                "lng": 17.105197
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 20,
+                "bookedBikes": 0,
+                "availableBikes": 20,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592690,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592507,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592475,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592309,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592194,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592169,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592118,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591880,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591449,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591377,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590992,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590865,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590722,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590703,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590472,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590358,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590307,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590217,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590141,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590136,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 20
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540518130",
+              "brandUid": "pl",
+              "name": "Żerniki Wrocławskie Pętla",
+              "number": 15321,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.033391,
+                "lng": 17.056056
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603920,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603907,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603905,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603874,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591860,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591058,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590841,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "540518329",
+              "brandUid": "pl",
+              "name": "Święta Katarzyna PKP",
+              "number": 15320,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.029405,
+                "lng": 17.123084
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 7,
+                "bookedBikes": 0,
+                "availableBikes": 7,
+                "bikeRacks": 6,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603925,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603911,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592916,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591890,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590735,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590434,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590212,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 7
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            }
+          ]
+        },
+        {
+          "name": "Czernica (WRM)",
+          "geoCoords": {
+            "lat": 51.087,
+            "lng": 17.1812
+          },
+          "landMarks": [],
+          "places": [
+            {
+              "uid": "544486355",
+              "brandUid": "pl",
+              "name": "Kamieniec Wrocławski - Szkoła",
+              "number": 15331,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.077945,
+                "lng": 17.17357
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 10,
+                "bookedBikes": 0,
+                "availableBikes": 10,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 592910,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592680,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592649,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592550,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592542,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592495,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591891,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591353,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 591316,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590908,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 10
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544486619",
+              "brandUid": "pl",
+              "name": "Dobrzykowice P&R",
+              "number": 15332,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.086982,
+                "lng": 17.18119
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 8,
+                "bookedBikes": 0,
+                "availableBikes": 8,
+                "bikeRacks": 10,
+                "freeRacks": 2,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603961,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603955,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603909,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603899,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603898,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603886,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603885,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 603863,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 8
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/s.png"
+            },
+            {
+              "uid": "544486874",
+              "brandUid": "pl",
+              "name": "Dobrzykowice ul. Szkolna",
+              "number": 15333,
+              "placeType": "STATION",
+              "terminalType": "STATION_4G",
+              "geoCoords": {
+                "lat": 51.094503,
+                "lng": 17.192763
+              },
+              "isPlaceNameHidden": false,
+              "availabilityStatus": {
+                "bikes": 12,
+                "bookedBikes": 0,
+                "availableBikes": 12,
+                "bikeRacks": 10,
+                "freeRacks": 0,
+                "freeSpecialRacks": 0
+              },
+              "bikes": [
+                {
+                  "number": 603781,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592724,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592707,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592668,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592609,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 592560,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590884,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590775,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590727,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590601,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590599,
+                  "bikeType": "STANDARD_4G",
+                  "battery": null
+                },
+                {
+                  "number": 590098,
+                  "bikeType": "ELECTRIC_4G",
+                  "battery": 39
+                }
+              ],
+              "bikeTypes": [
+                {
+                  "name": "STANDARD_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/regular-bg/standard.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/standard.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/standard.png",
+                  "count": 11
+                },
+                {
+                  "name": "ELECTRIC_4G",
+                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
+                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
+                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
+                  "count": 1
+                }
+              ],
+              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/se.png"
+            }
+          ]
+        }
+      ],
+      "isMainDomain": true
+    }
+  ]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,19 @@
+## Changelog
+
+#11 - Wrong station name for freestanding electric bikes - 2025-08-24
+- Fix: Normalize `station_name`/`station_id` to `freestanding` for any `placeType` starting with `FREESTANDING`.
+- Parse: Support both `bikes` objects and `bikeNumbers` lists within places.
+- Tests: Added focused tests using `data/sample/snapA.json` and `data/sample/snapB.json` plus a minimal freestanding-electric case.
+- Decision: Broad match on `placeType` to handle variations; prefer generic naming for freestanding entries.
+Basic project setup - 2025-08-18
+Finish raw data loading script - 2025-08-19
+- Goal: the `src/data_load_sqlite.py` script is almost done, check if everything is right, especially paths following rules in `docs/SPECS.md`
+- Acceptance:
+  - downloads the most recent csv file 
+  - transforms the data and stores in SQLite db
+  - saves cleaned data into separate csv file
+- create at least 1 test for that script
+- Note: don't change the script much, just check if it is OK
+Load all data to SQLite db - 2025-08-19
+- Create a script called `load_to_sqlite.py` which loads all csv files from `data/raw/2025` into SQLite db
+- The script should follow exactly the same process as `src/data_load_sqlite.py`

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -1,25 +1,57 @@
 # Wroclaw Bike Stats — SPEC
 
 ## 0. Overview
-Build a tiny web app that shows basic stats for city bike system in Wroclaw, Poland using its public API.
+Build a tiny web app that shows basic stats for the city bike system in Wroclaw, Poland.  
 Stack: Python 3.10, SQLite, HTML/CSS/JS, static website, zero-auth, minimal deps.
 
 ## 1. Goals (MVP)
-- Fetch bike rides data once per 24h and store inside sqlite database.
+- Fetch bike rides data once per 24h and store in SQLite (`bike_data.db`).
+- Fetch near real-time bike/station status data via official API and store in SQLite (`bike_status.db`).
 - Compute metrics for a single day (see point 4).
 - Single static webpage with KPI cards + table updated once a day.
-- Python script using jinja2 template to produce the final webpage with data.
+- Python script using Jinja2 template to produce the final webpage with data.
 
 ## 2. Non-Goals (for now)
-- No user accounts, no alerts, no web frameworks like Flask or Streamlit
+- No user accounts, no alerts, no web frameworks like Flask or Streamlit.
 
-## 3. Data Source
-- Raw data fetched in .csv format.
-- After fetching data is cleaned, transformed and stored in SQLite db.
-- SQLite db schema (table name: bike_rides): uid INTEGER, bike_number TEXT, start_time TIMESTAMP, end_time TIMESTAMP, start_station TEXT, end_station TEXT, duration INTEGER, lat_start REAL, lon_start REAL, lat_end REAL, lon_end REAL, distance REAL
+## 3. Data Sources
+### 3.1. Daily rides data
+- Source: raw daily `.csv` file with all rides.
+- ETL script: `src/data_load_sqlite.py`
+- Database: `data/processed/bike_data.db`
+- Schema (table: `bike_rides`):
+uid INTEGER,  
+bike_number TEXT,  
+start_time TIMESTAMP,  
+end_time TIMESTAMP,  
+start_station TEXT,  
+end_station TEXT,  
+duration INTEGER,  
+lat_start REAL,  
+lon_start REAL,  
+lat_end REAL,  
+lon_end REAL,  
+distance REAL
 
-## 4. Metrics 
-- All metrics are reffereing to the data from the last single day.
+### 3.2. Real-time bike status data
+- Source: official Nextbike API (JSON).
+- Fetch script: `src/fetch_nextbike.py` (stores raw JSON responses).
+- Transform script: `src/bike_status_changes.py` (parses events into SQLite).
+- Database: `data/processed/bike_status.db`
+- Schema (table: `bike_status_changes`):
+uid INTEGER PRIMARY KEY AUTOINCREMENT,  
+timestamp TEXT,  
+bike_id TEXT,  
+event_type TEXT,  
+station_name TEXT,  
+station_id TEXT,  
+lat REAL,  
+lon REAL,  
+bike_type TEXT,  
+battery REAL
+
+## 4. Metrics
+(Currently based on daily rides data; integration with real-time status TBD)
 - Total number of bike rentals.
 - Bike rentals by each hour a day (histogram).
 - Avg. bike ride duration.
@@ -29,28 +61,35 @@ Stack: Python 3.10, SQLite, HTML/CSS/JS, static website, zero-auth, minimal deps
 - Estimated daily revenue.
 
 ## 5. UI Requirements
-- TBD
+- Minimal static HTML/CSS/JS (templated via Jinja2).
+- Show KPI cards and tables for one selected day.
+- Future: possible integration of real-time status visualizations.
 
 ## 6. CLI / Scripts
-- TBD
+- `src/data_load_sqlite.py` → ETL daily rides (CSV → SQLite).
+- `src/fetch_nextbike.py` → fetch raw station/bike JSON snapshots.
+- `src/bike_status_changes.py` → process snapshots → `bike_status_changes` table.
+- Report generator script (TBD) → produce final static HTML report.
 
 ## 7. Directory Contract
-- SQLite db location: `data/processed/bike_data.db`
-- SQLite db location for bike status changes: `data/processed/bike_status.db`
-- Raw data location: `data/raw/2025`
-- Cleaned csv file location: `data/interim`
-- File with bike stations name, lat/lon coordinates: `data/bike_stations.csv`
-- Changelog location: `docs/CHANGELOG.md`
-- Don't edit and modify files in these locations.
+- Daily rides DB: `data/processed/bike_data.db`
+- Bike status DB: `data/processed/bike_status.db`
+- Raw data: `data/raw/2025`
+- Interim cleaned CSV: `data/interim`
+- Bike stations reference file: `data/bike_stations.csv`    
+- Don’t edit or modify files in these locations manually.
 
 ## 8. Quality & Constraints
-- Keep deps minimal (requests, pandas/pyarrow, pydantic optional).
+- Keep deps minimal (`requests`, `pandas`/`pyarrow`; `pydantic` optional).
 - 95% of logic in pure functions with unit tests.
-- Lint with ruff; test with pytest; type hints encouraged.
+- Lint with `ruff`; test with `pytest`; type hints encouraged.
 
 ## 9. Acceptance Tests (agent must satisfy)
 - TBD
 
 ## 10. Future (parking lot)
-- Map view, historical data from past years, bike station data, ML prediction algorithm.
-- Historical data for every single day in the current year.
+- Define how daily ride data and real-time status data complement each other.
+- Map view of stations and bike movements.
+- Historical data from past years.
+- ML prediction algorithms (demand, redistribution).
+- Revenue analysis at weekly/monthly level.


### PR DESCRIPTION
Issue body:

- There is a wrong `station_name` field value in the database for all freestanding electric bikes.
- Instead of the "freestanding" value there is a bike name and id eg. `BIKE 590066`
- Write also tests to check if the change will work.
- For the reference below there is a part of api response for freestanding electric bike:
```
{
              "uid": "568267505",
              "brandUid": "pl",
              "name": "BIKE 590066",
              "number": 0,
              "placeType": "FREESTANDING_ELECTRIC_BIKE",
              "terminalType": "UNKNOWN",
              "geoCoords": {
                "lat": 51.14448,
                "lng": 16.854524
              },
              "isPlaceNameHidden": false,
              "availabilityStatus": {
                "bikes": 1,
                "bookedBikes": 0,
                "availableBikes": 1,
                "bikeRacks": 0,
                "freeRacks": 0,
                "freeSpecialRacks": 0
              },
              "bikes": [
                {
                  "number": 590066,
                  "bikeType": "ELECTRIC_4G",
                  "battery": 30
                }
              ],
              "bikeTypes": [
                {
                  "name": "ELECTRIC_4G",
                  "imgUrlRegularBg": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular-bg/electric.png",
                  "imgUrlRegular": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/_default/regular/electric.png",
                  "imgUrlProfile": "https://d3b2ne12ehawlb.cloudfront.net/img/bikes-icons/pl/profile/electric.png",
                  "count": 1
                }
              ],
              "imgUrlPlaceDot": "https://d3b2ne12ehawlb.cloudfront.net/img/places-dots/_default/e.png"
            }
```

Summary of work:
- Fix: Normalize `station_name`/`station_id` to `freestanding` for any `placeType` starting with `FREESTANDING`.
- Parse: Support both `bikes` objects and `bikeNumbers` lists within places.
- Tests: Added focused tests using `data/sample/snapA.json` and `data/sample/snapB.json` plus a minimal freestanding-electric case.

Decisions / notes:
- Broad match on `placeType` to handle variations; prefer generic naming for freestanding entries.
