### PR TITLE
Add pipeline and centralized logging

### DIFF
--- a/cron.txt
+++ b/cron.txt
@@ -1,0 +1,3 @@
+# Cron jobs for Wroclaw Bike Stats ETL
+# Run unified pipeline every minute
+* * * * * cd /path/to/wroclaw-bike-stats && python src/pipeline.py >> data/logs/cron.log 2>&1

--- a/cron.txt
+++ b/cron.txt
@@ -1,3 +1,0 @@
-# Cron jobs for Wroclaw Bike Stats ETL
-# Run unified pipeline every minute
-* * * * * cd /path/to/wroclaw-bike-stats && python src/pipeline.py >> data/logs/cron.log 2>&1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+#12 - Add unified pipeline and logging - 2025-08-25
+- Feat: add `src/pipeline.py` orchestrating fetch and status change processing.
+- Feat: central logging with rotating file handler and start/end markers.
+- Chore: replace separate cron jobs with single pipeline invocation.
+
 #11 - Wrong station name for freestanding electric bikes - 2025-08-24
 - Fix: Normalize `station_name`/`station_id` to `freestanding` for any `placeType` starting with `FREESTANDING`.
 - Parse: Support both `bikes` objects and `bikeNumbers` lists within places.

--- a/src/fetch_nextbike.py
+++ b/src/fetch_nextbike.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
+"""Fetch raw bike status data from the Nextbike API."""
+
+from __future__ import annotations
+
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.request import urlopen, Request
-from urllib.error import URLError, HTTPError
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 # === CONFIG ===
 # Resolve repo root and default data directory (pathlib-based)
@@ -11,6 +16,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = REPO_ROOT / "data" / "raw" / "api"
 URL = "https://api-gateway.nextbike.pl/api/maps/service/pl/locations"
 TIMEZONE = "Europe/Warsaw"  # for local timestamp in filename
+
+logger = logging.getLogger(__name__)
 
 # === TIMEZONE HANDLING (stdlib only) ===
 try:
@@ -26,44 +33,55 @@ def now_local_for_filename():
     return datetime.now(tz=ZONE).strftime("%Y-%m-%d_%H_%M_%S")
 
 def fetch_json(url: str):
-    req = Request(url, headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"})
+    req = Request(
+        url,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+                " AppleWebKit/537.36 (KHTML, like Gecko)"
+                " Chrome/91.0.4472.124 Safari/537.36"
+            )
+        },
+    )
     with urlopen(req, timeout=30) as resp:
         charset = resp.headers.get_content_charset() or "utf-8"
         raw = resp.read().decode(charset, errors="replace")
         return json.loads(raw)
 
-def main():
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
+def main() -> Path | None:
+    """Fetch the latest snapshot and save it under ``data/raw/api``.
 
+    Returns the path to the saved file on success, otherwise ``None``.
+    """
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    logger.info("Fetching bike status snapshot from %s", URL)
     try:
         payload = fetch_json(URL)
     except HTTPError as e:
-        print(f"[ERROR] HTTP {e.code}: {e.reason}")
-        return
+        logger.error("HTTP %s: %s", e.code, e.reason)
+        return None
     except URLError as e:
-        print(f"[ERROR] URL error: {e.reason}")
-        return
-    except Exception as e:
-        print(f"[ERROR] Unexpected: {e}")
-        return
+        logger.error("URL error: %s", e.reason)
+        return None
+    except Exception as e:  # pragma: no cover - unexpected failures
+        logger.error("Unexpected error: %s", e)
+        return None
 
     timestamp_iso = now_local_iso()
 
-    # Attach the timestamp to the JSON. If it's not a dict, wrap it.
     if isinstance(payload, dict):
         payload["_fetched_at"] = timestamp_iso
     else:
         payload = {"_fetched_at": timestamp_iso, "data": payload}
 
-    # Filename with local timestamp
     fname = f"bike_rides_{now_local_for_filename()}.json"
     fpath = DATA_DIR / fname
-
-    # Write pretty but compact-ish JSON
     with open(fpath, "w", encoding="utf-8") as f:
         json.dump(payload, f, ensure_ascii=False, indent=2)
+    logger.info("Saved snapshot to %s", fpath)
+    return fpath
 
-    print(f"[OK] Saved {fpath}")
 
 if __name__ == "__main__":
     main()

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,0 +1,42 @@
+"""Logging configuration for the ETL pipeline."""
+from __future__ import annotations
+
+import logging.config
+from pathlib import Path
+from logging.handlers import RotatingFileHandler  # noqa: F401  # ensure import for config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOG_PATH = REPO_ROOT / "data" / "logs" / "pipeline.log"
+
+
+def setup_logging(log_path: Path = LOG_PATH) -> None:
+    """Configure root logger with console and rotating file handlers."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    config = {
+        "version": 1,
+        "formatters": {
+            "standard": {
+                "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": "INFO",
+                "formatter": "standard",
+            },
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "level": "INFO",
+                "formatter": "standard",
+                "filename": str(log_path),
+                "maxBytes": 1_000_000,
+                "backupCount": 5,
+            },
+        },
+        "root": {
+            "level": "INFO",
+            "handlers": ["console", "file"],
+        },
+    }
+    logging.config.dictConfig(config)

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,37 @@
+"""Run the full ETL pipeline for bike status data."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import bike_status_changes  # noqa: E402
+import fetch_nextbike  # noqa: E402
+from logging_config import setup_logging  # noqa: E402
+
+
+def main() -> None:
+    setup_logging()
+    logger = logging.getLogger("pipeline")
+    start = datetime.utcnow().isoformat()
+    logger.info("ETL pipeline started", extra={"start": start})
+
+    snapshot_path = fetch_nextbike.main()
+    if snapshot_path is None:
+        logger.error("Snapshot fetch failed; aborting")
+        return
+    logger.info("Fetched snapshot %s", snapshot_path)
+
+    result = bike_status_changes.main()
+    files = ", ".join(p.name for p in result.get("files", []))
+    logger.info(
+        "Processed snapshots: %s; added %d records",
+        files,
+        result.get("events", 0),
+    )
+    end = datetime.utcnow().isoformat()
+    logger.info("ETL pipeline finished", extra={"end": end})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/pipeline.py` to run fetch and status change steps in sequence
- introduce reusable logging configuration with rotating file handler
- log snapshot processing details and update cron schedule

## Testing
- `ruff check src/pipeline.py src/fetch_nextbike.py src/bike_status_changes.py src/logging_config.py`
- `pytest -q` *(fails: no bike status snapshots or raw CSV test data available)*

------
https://chatgpt.com/codex/tasks/task_e_68ac34fd3d70832bae7ce63804acdc76